### PR TITLE
Added a setting to force global mount namespace

### DIFF
--- a/apd/src/apd.rs
+++ b/apd/src/apd.rs
@@ -199,7 +199,10 @@ pub fn root_shell() -> Result<()> {
 
             // switch to global mount namespace
             #[cfg(any(target_os = "linux", target_os = "android"))]
-            if mount_master {
+            let global_namespace_enable =
+                std::fs::read_to_string("/data/adb/.global_namespace_enable")
+                    .unwrap_or("0".to_string());
+            if global_namespace_enable.trim() == "1" || mount_master {
                 let _ = utils::switch_mnt_ns(1);
                 let _ = utils::unshare_mnt_ns();
             }

--- a/app/src/main/java/me/bmax/apatch/APatchApp.kt
+++ b/app/src/main/java/me/bmax/apatch/APatchApp.kt
@@ -42,6 +42,7 @@ class APApplication : Application() {
         val PACKAGE_CONFIG_FILE = APATCH_FLODER + "package_config"
         val SU_PATH_FILE = APATCH_FLODER + "su_path"
         val SAFEMODE_FILE = "/dev/.sefemode"
+        val GLOBAL_NAMESPACE_FILE = "/data/adb/.global_namespace_enable"
 
         val APATCH_VERSION_PATH = APATCH_FLODER + "version"
         val MAGISKPOLICY_BIN_PATH = APATCH_BIN_FLODER + "magiskpolicy"

--- a/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
+++ b/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
@@ -1,7 +1,6 @@
 package me.bmax.apatch.util
 
 import android.net.Uri
-import android.os.SystemClock
 import android.util.Log
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.Shell
@@ -32,7 +31,13 @@ fun createRootShell(): Shell {
     Shell.enableVerboseLogging = BuildConfig.DEBUG
     val builder = Shell.Builder.create()
     return try {
-        builder.build(getKPatchPath(), APApplication.superKey, "su", "-x", APApplication.MAGISK_SCONTEXT)
+        builder.build(
+            getKPatchPath(),
+            APApplication.superKey,
+            "su",
+            "-x",
+            APApplication.MAGISK_SCONTEXT
+        )
     } catch (e: Throwable) {
         Log.e(TAG, "su failed: ", e)
         builder.build("sh")
@@ -43,13 +48,19 @@ fun createRootShellForLog(): Shell {
     Shell.enableVerboseLogging = BuildConfig.DEBUG
     val builder = Shell.Builder.create()
     return try {
-        builder.build(getKPatchPath(), APApplication.superKey, "su", "-x", APApplication.MAGISK_SCONTEXT)
+        builder.build(
+            getKPatchPath(),
+            APApplication.superKey,
+            "su",
+            "-x",
+            APApplication.MAGISK_SCONTEXT
+        )
     } catch (e: Throwable) {
         Log.e(TAG, "su failed: ", e)
         return try {
             Log.e(TAG, "retry su: ", e)
             builder.build("su")
-        } catch(e: Throwable) {
+        } catch (e: Throwable) {
             Log.e(TAG, "retry su failed: ", e)
             builder.build("sh")
         }
@@ -94,7 +105,12 @@ fun uninstallModule(id: String): Boolean {
     return result
 }
 
-fun installModule(uri: Uri, onFinish: (Boolean) -> Unit, onStdout: (String) -> Unit, onStderr: (String) -> Unit): Boolean {
+fun installModule(
+    uri: Uri,
+    onFinish: (Boolean) -> Unit,
+    onStdout: (String) -> Unit,
+    onStderr: (String) -> Unit
+): Boolean {
     val resolver = apApp.contentResolver
     with(resolver.openInputStream(uri)) {
         val file = File(apApp.cacheDir, "module.zip")
@@ -118,7 +134,8 @@ fun installModule(uri: Uri, onFinish: (Boolean) -> Unit, onStdout: (String) -> U
         }
 
         val result =
-            shell.newJob().add("${APApplication.APD_PATH} $cmd").to(stdoutCallback, stderrCallback).exec()
+            shell.newJob().add("${APApplication.APD_PATH} $cmd").to(stdoutCallback, stderrCallback)
+                .exec()
         Log.i(TAG, "install module $uri result: $result")
 
         file.delete()
@@ -151,6 +168,21 @@ fun hasMagisk(): Boolean {
     return result.isSuccess
 }
 
+fun isGlobalNamespaceEnabled(): Boolean {
+    val result =
+        ShellUtils.fastCmd("nsenter --mount=/proc/1/ns/mnt cat ${APApplication.GLOBAL_NAMESPACE_FILE}")
+    Log.i(TAG, "is global namespace enabled: $result")
+    return result == "1"
+}
+
+fun setGlobalNamespaceEnabled(value: String) {
+    getRootShell().newJob()
+        .add("nsenter --mount=/proc/1/ns/mnt echo $value > ${APApplication.GLOBAL_NAMESPACE_FILE}")
+        .submit { result ->
+            Log.i(TAG, "setGlobalNamespaceEnabled result: ${result.isSuccess} [${result.out}]")
+        }
+}
+
 fun forceStopApp(packageName: String) {
     val shell = getRootShell()
     val result = shell.newJob().add("am force-stop $packageName").exec()
@@ -159,7 +191,8 @@ fun forceStopApp(packageName: String) {
 
 fun launchApp(packageName: String) {
     val shell = getRootShell()
-    val result = shell.newJob().add("monkey -p $packageName -c android.intent.category.LAUNCHER 1").exec()
+    val result =
+        shell.newJob().add("monkey -p $packageName -c android.intent.category.LAUNCHER 1").exec()
     Log.i(TAG, "launch $packageName result: $result")
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <string name="about">About</string>
     <string name="settings_app_language">Language</string>
     <string name="system_default">System default</string>
+    <string name="settings_global_namespace_mode">Global Namespace Mode</string>
+    <string name="settings_global_namespace_mode_summary">All root sessions use the global mount namespace</string>
 
     <string name="home_learn_apatch">Learn AndroidPatch</string>
     <string name="home_learn_android_patch_url">https://github.com/bmax121/APatch</string>


### PR DESCRIPTION
This pull request introduces a setting to enforce the global mount namespace for root sessions. 
This is achieved by reading an hidden file called `global_namespace_enable` that will be placed in `/data/adb/`. 
![toggle](https://github.com/bmax121/APatch/assets/8174240/6d43f30c-eaaf-4b6e-b481-5d3fa9378808)

Some apps, such as [Solid Explorer](https://play.google.com/store/apps/details?id=pl.solidexplorer2), do not function properly with the default namespace, and forcing the global mount resolves the issue.

| ![before](https://github.com/bmax121/APatch/assets/8174240/20154508-2e89-4a22-a86c-dc49b8ba60d7) | ![after](https://github.com/bmax121/APatch/assets/8174240/f92133d3-d6f9-438b-8998-c36260ca3ce4) |
| --- | --- |
| Toggle OFF | Toggle ON |

I don't know if having all root sessions use the global namespace can cause any issues somewhere; with Magisk, I've always kept it that way and haven't experienced any particular problems.

P.S.: Make sure the toggle is working properly before merging; as you can see in the video, it seems to be functioning correctly, however, I had some difficulty testing it because in certain circumstances (which I couldn't identify, but it was probably just a problem with my phone), it appeared not to work 🤷🏻‍♂️

https://github.com/bmax121/APatch/assets/8174240/71fe3b05-02fb-4519-aac1-e8a78b1dee07

EDIT: it seems to work https://t.me/APatchGroup/34523 😄