### PR TITLE
[Fix] global namespace mode setting

### DIFF
--- a/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
+++ b/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
@@ -29,7 +29,9 @@ fun getRootShell(): Shell {
 
 fun createRootShell(): Shell {
     Shell.enableVerboseLogging = BuildConfig.DEBUG
-    val builder = Shell.Builder.create()
+    val builder = Shell.Builder.create().apply {
+        setFlags(Shell.FLAG_MOUNT_MASTER)
+    }
     return try {
         builder.build(
             getKPatchPath(),
@@ -169,8 +171,9 @@ fun hasMagisk(): Boolean {
 }
 
 fun isGlobalNamespaceEnabled(): Boolean {
+    val shell = getRootShell()
     val result =
-        ShellUtils.fastCmd("nsenter --mount=/proc/1/ns/mnt cat ${APApplication.GLOBAL_NAMESPACE_FILE}")
+        ShellUtils.fastCmd(shell, "nsenter --mount=/proc/1/ns/mnt cat ${APApplication.GLOBAL_NAMESPACE_FILE}")
     Log.i(TAG, "is global namespace enabled: $result")
     return result == "1"
 }


### PR DESCRIPTION
Some users (as reported in issue #134) are experiencing an issue with the **Global Namespace Mode** setting not remaining active after closing and reopening the settings. 
This problem is due to the fact that the command `cat /data/adb/.global_namespace_enable` returns nothing and exits with _error code 1_, even though the file is present.
Actually, the issue seems to affect all options that execute commands with the root shell, such as the reboot command. 
After some time, the problem started appearing on my phone as well, but after making some changes, it seems to have been resolved. 
Let's try to merge it and see if the issue is also resolved for other users.