### PR TITLE
feat: update kernel on kpatch update and update Home screen

### DIFF
--- a/apd/src/apd.rs
+++ b/apd/src/apd.rs
@@ -199,7 +199,10 @@ pub fn root_shell() -> Result<()> {
 
             // switch to global mount namespace
             #[cfg(any(target_os = "linux", target_os = "android"))]
-            if mount_master {
+            let global_namespace_enable =
+                std::fs::read_to_string("/data/adb/.global_namespace_enable")
+                    .unwrap_or("0".to_string());
+            if global_namespace_enable.trim() == "1" || mount_master {
                 let _ = utils::switch_mnt_ns(1);
                 let _ = utils::unshare_mnt_ns();
             }

--- a/app/src/main/java/me/bmax/apatch/APatchApp.kt
+++ b/app/src/main/java/me/bmax/apatch/APatchApp.kt
@@ -44,6 +44,7 @@ class APApplication : Application() {
         val PACKAGE_CONFIG_FILE = APATCH_FLODER + "package_config"
         val SU_PATH_FILE = APATCH_FLODER + "su_path"
         val SAFEMODE_FILE = "/dev/.safemode"
+        val GLOBAL_NAMESPACE_FILE = "/data/adb/.global_namespace_enable"
 
         val KPATCH_VERSION_PATH = APATCH_FLODER + "kpatch_version"
         val APATCH_VERSION_PATH = APATCH_FLODER + "apatch_version"

--- a/app/src/main/java/me/bmax/apatch/APatchApp.kt
+++ b/app/src/main/java/me/bmax/apatch/APatchApp.kt
@@ -10,11 +10,11 @@ import coil.Coil
 import coil.ImageLoader
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.Shell
-import me.bmax.apatch.ui.screen.getManagerVersion
 import me.zhanghai.android.appiconloader.coil.AppIconFetcher
 import me.zhanghai.android.appiconloader.coil.AppIconKeyer
 import java.io.File
 import kotlin.concurrent.thread
+import org.json.JSONArray
 
 lateinit var apApp: APApplication
 
@@ -23,13 +23,15 @@ val TAG = "APatch"
 class APApplication : Application() {
     enum class State {
         UNKNOWN_STATE,
-        KERNELPATCH_READY,
+        KERNELPATCH_INSTALLED,
         KERNELPATCH_NEED_UPDATE,
-        ANDROIDPATCH_NEED_UPDATE,
-        ANDROIDPATCH_INSTALLING,
-        ANDROIDPATCH_UNINSTALLING,
+        ANDROIDPATCH_READY,
         ANDROIDPATCH_INSTALLED,
+        ANDROIDPATCH_INSTALLING,
+        ANDROIDPATCH_NEED_UPDATE,
+        ANDROIDPATCH_UNINSTALLING,
     }
+
     companion object {
         val APD_PATH = "/data/adb/apd"
         val KPATCH_PATH = "/data/adb/kpatch"
@@ -41,9 +43,10 @@ class APApplication : Application() {
         val KPATCH_LINK_PATH = APATCH_BIN_FLODER + "kpatch"
         val PACKAGE_CONFIG_FILE = APATCH_FLODER + "package_config"
         val SU_PATH_FILE = APATCH_FLODER + "su_path"
-        val SAFEMODE_FILE = "/dev/.sefemode"
+        val SAFEMODE_FILE = "/dev/.safemode"
 
-        val APATCH_VERSION_PATH = APATCH_FLODER + "version"
+        val KPATCH_VERSION_PATH = APATCH_FLODER + "kpatch_version"
+        val APATCH_VERSION_PATH = APATCH_FLODER + "apatch_version"
         val MAGISKPOLICY_BIN_PATH = APATCH_BIN_FLODER + "magiskpolicy"
         val BUSYBOX_BIN_PATH = APATCH_BIN_FLODER + "busybox"
         val RESETPROP_BIN_PATH = APATCH_BIN_FLODER + "resetprop"
@@ -52,23 +55,58 @@ class APApplication : Application() {
         val DEFAULT_SU_PATH = "/system/bin/kp"
         val LEGACY_SU_PATH = "/system/bin/su"
 
-        // todo: should we store super_key in SharedPreferences
+        // TODO: encrypt super_key before saving it on SharedPreferences
         private const val SUPER_KEY = "super_key"
         private const val SHOW_BACKUP_WARN = "show_backup_warning"
         private lateinit var sharedPreferences: SharedPreferences
 
+        private val logCallback: CallbackList<String?> = object : CallbackList<String?>() {
+            override fun onAddElement(s: String?) {
+                Log.d(TAG, s.toString())
+            }
+        }
+
+        private val _kpStateLiveData = MutableLiveData<State>(State.UNKNOWN_STATE)
+        val kpStateLiveData: LiveData<State> = _kpStateLiveData
+
         private val _apStateLiveData = MutableLiveData<State>(State.UNKNOWN_STATE)
         val apStateLiveData: LiveData<State> = _apStateLiveData
 
-        var apatchVersion: Int = 0
+        var kPatchVersion: String = ""
+        var aPatchVersion: Int = 0
 
-        fun uninstall() {
-            if(_apStateLiveData.value != State.ANDROIDPATCH_INSTALLED) return
+        fun installKpatch() {
+            if (_kpStateLiveData.value != State.KERNELPATCH_NEED_UPDATE) {
+                return
+            }
+
+            thread {
+                val rc = Natives.su(0, null)
+                if (!rc) {
+                    Log.e(TAG, "Native.su failed: " + rc)
+                    return@thread
+                }
+
+                kPatchVersion = getKernelPatchVersion()
+
+                val cmds = arrayOf(
+                    "echo ${kPatchVersion} > ${KPATCH_VERSION_PATH}",
+                )
+
+                Shell.getShell().newJob().add(*cmds).to(logCallback, logCallback).exec()
+
+                Log.d(TAG, "KPatch installed ...")
+                _kpStateLiveData.postValue(State.KERNELPATCH_INSTALLED)
+            }
+        }
+
+        fun uninstallApatch() {
+            if (_apStateLiveData.value != State.ANDROIDPATCH_INSTALLED) return
             _apStateLiveData.value = State.ANDROIDPATCH_UNINSTALLING
 
             thread {
                 val rc = Natives.su(0, null)
-                if(!rc) {
+                if (!rc) {
                     Log.e(TAG, "Native.su failed: " + rc)
                     _apStateLiveData.postValue(State.ANDROIDPATCH_INSTALLED)
                     return@thread
@@ -79,33 +117,28 @@ class APApplication : Application() {
                 File(APATCH_VERSION_PATH).delete()
                 File(APD_PATH).delete()
                 // Reserved, used to obtain logs
-//                File(KPATCH_PATH).delete()
+                // File(KPATCH_PATH).delete()
                 File(APATCH_FLODER).deleteRecursively()
 
                 Log.d(TAG, "APatch removed ...")
 
-                _apStateLiveData.postValue(State.KERNELPATCH_READY)
+                _apStateLiveData.postValue(State.ANDROIDPATCH_READY)
             }
         }
 
-        fun install() {
+        fun installApatch() {
             val state = _apStateLiveData.value
-            if(_apStateLiveData.value != State.KERNELPATCH_READY
-                && _apStateLiveData.value != State.ANDROIDPATCH_NEED_UPDATE) {
+            if (_apStateLiveData.value != State.ANDROIDPATCH_READY &&
+                _apStateLiveData.value != State.ANDROIDPATCH_NEED_UPDATE) {
                 return
             }
             _apStateLiveData.value = State.ANDROIDPATCH_INSTALLING
 
             val nativeDir = apApp.applicationInfo.nativeLibraryDir
-            val logCallback: CallbackList<String?> = object : CallbackList<String?>() {
-                override fun onAddElement(s: String?) {
-                    Log.d(TAG, s.toString())
-                }
-            }
 
             thread {
                 val rc = Natives.su(0, null)
-                if(!rc) {
+                if (!rc) {
                     Log.e(TAG, "Native.su failed: " + rc)
                     // revert state
                     _apStateLiveData.postValue(state)
@@ -138,6 +171,9 @@ class APApplication : Application() {
                     "[ -s ${SU_PATH_FILE} ] || echo ${LEGACY_SU_PATH} > ${SU_PATH_FILE}",
                     "echo ${getManagerVersion().second} > ${APATCH_VERSION_PATH}",
 
+                    "touch ${KPATCH_VERSION_PATH}",
+                    "[ -s ${KPATCH_VERSION_PATH} ] || echo ${getKernelPatchVersion()} > ${KPATCH_VERSION_PATH}",
+
                     "restorecon -R ${APATCH_FLODER}",
 
                     "${KPATCH_PATH} ${superKey} android_user init",
@@ -145,9 +181,26 @@ class APApplication : Application() {
 
                 Shell.getShell().newJob().add(*cmds).to(logCallback, logCallback).exec()
 
+                aPatchVersion = getManagerVersion().second
+                kPatchVersion = getKernelPatchVersion()
+
                 Log.d(TAG, "APatch installed ...")
                 _apStateLiveData.postValue(State.ANDROIDPATCH_INSTALLED)
             }
+        }
+
+        fun getManagerVersion(): Pair<String, Int> {
+            val packageInfo = apApp.packageManager.getPackageInfo(apApp.packageName, 0)
+            return Pair(packageInfo.versionName, packageInfo.versionCode)
+        }
+
+        fun getKernelPatchVersion(): String {
+            val kernelPatchVersion = Natives.kernelPatchVersion()
+            return "%d.%d.%d".format(
+                kernelPatchVersion.and(0xff0000).shr(16),
+                kernelPatchVersion.and(0xff00).shr(8),
+                kernelPatchVersion.and(0xff)
+            )
         }
 
         var superKey: String = ""
@@ -155,41 +208,55 @@ class APApplication : Application() {
             private set(value) {
                 field = value
                 val ready = Natives.nativeReady(value)
-                _apStateLiveData.value = if(ready) State.KERNELPATCH_READY else State.UNKNOWN_STATE
-                Log.d(TAG, "state: " + _apStateLiveData.value)
+                _kpStateLiveData.value = if (ready) State.KERNELPATCH_INSTALLED else State.UNKNOWN_STATE
+                _apStateLiveData.value = if (ready) State.ANDROIDPATCH_READY else State.UNKNOWN_STATE
+                Log.d(TAG, "state: " + _kpStateLiveData.value)
                 sharedPreferences.edit().putString(SUPER_KEY, value).apply()
 
                 thread {
                     val rc = Natives.su(0, null)
-                    if(!rc) {
+                    if (!rc) {
                         Log.e(TAG, "su failed: " + rc)
                         return@thread
                     }
 
-                    val vf = File(APATCH_VERSION_PATH)
+                    val kv = File(KPATCH_VERSION_PATH)
+                    val kvn = getKernelPatchVersion()
+                    if (kv.exists()) {
+                        kPatchVersion = kv.readLines().get(0)
+                        if (kPatchVersion == kvn) {
+                            _kpStateLiveData.postValue(State.KERNELPATCH_INSTALLED)
+                            Log.d(TAG, "state: " + State.KERNELPATCH_INSTALLED + ", version: " + kPatchVersion)
+                        } else {
+                            _kpStateLiveData.postValue(State.KERNELPATCH_NEED_UPDATE)
+                            Log.d(TAG, "state: " + State.KERNELPATCH_NEED_UPDATE + ", version: " + kPatchVersion + "->" + kvn)
+                        }
+                    }
+
+                    val av = File(APATCH_VERSION_PATH)
                     val mgv = getManagerVersion().second
-                    if(vf.exists()) {
-                        //
-                        apatchVersion = vf.readLines().get(0).toInt()
-                        if(apatchVersion == mgv) {
+                    if (av.exists()) {
+                        aPatchVersion = av.readLines().get(0).toInt()
+                        if (aPatchVersion == mgv) {
                             _apStateLiveData.postValue(State.ANDROIDPATCH_INSTALLED)
-                            Log.d(TAG, "state: " + State.ANDROIDPATCH_INSTALLED + ", version: " + apatchVersion)
+                            Log.d(TAG, "state: " + State.ANDROIDPATCH_INSTALLED + ", version: " + aPatchVersion)
                         } else {
                             _apStateLiveData.postValue(State.ANDROIDPATCH_NEED_UPDATE)
-                            Log.d(TAG, "state: " + State.ANDROIDPATCH_NEED_UPDATE + ", version: " + apatchVersion + "->" + mgv)
+                            Log.d(TAG, "state: " + State.ANDROIDPATCH_NEED_UPDATE + ", version: " + aPatchVersion + "->" + mgv)
                         }
 
                         // su path
                         val suPathFile = File(SU_PATH_FILE)
-                        if(suPathFile.exists()) {
+                        if (suPathFile.exists()) {
                             val suPath = suPathFile.readLines()[0].trim()
-                            if(!Natives.suPath().equals(suPath)) {
+                            if (!Natives.suPath().equals(suPath)) {
                                 Log.d(TAG, "su path: " + suPath)
                                 Natives.resetSuPath(suPath)
                             }
                         }
-                        return@thread
                     }
+
+                    return@thread
                 }
             }
     }
@@ -206,7 +273,6 @@ class APApplication : Application() {
         super.onCreate()
         apApp = this
 
-        // todo:
         sharedPreferences = getSharedPreferences("config", Context.MODE_PRIVATE)
         superKey = sharedPreferences.getString(SUPER_KEY, "") ?: ""
 

--- a/app/src/main/java/me/bmax/apatch/Natives.kt
+++ b/app/src/main/java/me/bmax/apatch/Natives.kt
@@ -58,7 +58,7 @@ object Natives {
     }
 
     private external fun nativeKernelPatchVersion(superKey: String): Long
-    fun kerenlPatchVersion(): Long {
+    fun kernelPatchVersion(): Long {
         return nativeKernelPatchVersion(APApplication.superKey)
     }
     private external fun nativeLoadKernelPatchModule(superKey: String, modulePath: String, args: String): Long

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.bmax.apatch.R
 import me.bmax.apatch.TAG
+import me.bmax.apatch.APApplication
 import me.bmax.apatch.apApp
 import me.bmax.apatch.util.reboot
 import java.io.File
@@ -195,7 +196,7 @@ fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolea
         apApp.assets.open(script).writeTo(dest)
     }
 
-    val apVer = getManagerVersion().second
+    val apVer = APApplication.getManagerVersion().second
     val rand = (1..4).map { ('a'..'z').random() }.joinToString("")
     val outFilename = "apatch_${apVer}_${rand}_boot.img"
     val patchCommand = if (uri != null) "sh boot_patch.sh $superKey ${srcBoot?.path}" else "sh boot_patch.sh $superKey"
@@ -230,7 +231,7 @@ fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolea
             } else {
                 newBootFile.inputStream().copyAndClose(outPath.outputStream())
             }
-            
+
             if (succ) {
                 logs.add(" Write patched boot.img was successful")
                 logs.add(" Output file is written to ")

--- a/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
+++ b/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
@@ -29,7 +29,9 @@ fun getRootShell(): Shell {
 
 fun createRootShell(): Shell {
     Shell.enableVerboseLogging = BuildConfig.DEBUG
-    val builder = Shell.Builder.create()
+    val builder = Shell.Builder.create().apply {
+        setFlags(Shell.FLAG_MOUNT_MASTER)
+    }
     return try {
         builder.build(
             getKPatchPath(),
@@ -175,8 +177,9 @@ fun hasMagisk(): Boolean {
 }
 
 fun isGlobalNamespaceEnabled(): Boolean {
+    val shell = getRootShell()
     val result =
-        ShellUtils.fastCmd("nsenter --mount=/proc/1/ns/mnt cat ${APApplication.GLOBAL_NAMESPACE_FILE}")
+        ShellUtils.fastCmd(shell, "nsenter --mount=/proc/1/ns/mnt cat ${APApplication.GLOBAL_NAMESPACE_FILE}")
     Log.i(TAG, "is global namespace enabled: $result")
     return result == "1"
 }

--- a/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
+++ b/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
@@ -76,6 +76,12 @@ fun getModuleCount(): Int {
     }.getOrElse { return 0 }
 }
 
+fun getSuperuserCount(): Int {
+    val shell = getRootShell()
+    val out = shell.newJob().add("${APApplication.KPATCH_PATH} ${APApplication.superKey} sumgr list | wc -l").to(ArrayList(), null).exec().out
+    return out[0].toIntOrNull() ?: 0
+}
+
 fun toggleModule(id: String, enable: Boolean): Boolean {
     val cmd = if (enable) {
         "module enable $id"

--- a/app/src/main/java/me/bmax/apatch/util/LogEvent.kt
+++ b/app/src/main/java/me/bmax/apatch/util/LogEvent.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.os.Build
 import android.system.Os
 import com.topjohnwu.superuser.ShellUtils
+import me.bmax.apatch.APApplication
 import me.bmax.apatch.Natives
-import me.bmax.apatch.ui.screen.getManagerVersion
 import java.io.File
 import java.io.FileWriter
 import java.io.PrintWriter
@@ -62,7 +62,7 @@ fun getBugreportFile(context: Context): File {
         pw.println("PREVIEW_SDK: " + Build.VERSION.PREVIEW_SDK_INT)
         pw.println("FINGERPRINT: " + Build.FINGERPRINT)
         pw.println("DEVICE: " + Build.DEVICE)
-        pw.println("Manager: " + getManagerVersion())
+        pw.println("Manager: " + APApplication.getManagerVersion())
         pw.println("SELinux: $selinux")
 
         val uname = Os.uname()
@@ -72,8 +72,8 @@ fun getBugreportFile(context: Context): File {
         pw.println("Nodename: ${uname.nodename}")
         pw.println("Sysname: ${uname.sysname}")
 
-        pw.println("KPatch: ${Natives.kerenlPatchVersion()}")
-        pw.println("APatch: ${getManagerVersion()}")
+        pw.println("KPatch: ${APApplication.getKernelPatchVersion()}")
+        pw.println("APatch: ${APApplication.getManagerVersion()}")
         val safeMode = false
         pw.println("SafeMode: $safeMode")
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,15 +39,18 @@
     <string name="home_working">Working</string>
     <string name="home_installing">Installing</string>
     <string name="home_need_update">New version available</string>
-    <string name="kpatch_version">Version: %d.%d.%d</string>
-    <string name="apatch_version">Version:\n%s</string>
-    <string name="apatch_version_update">Version:\n%s -&gt; %s</string>
-    <string name="home_su_path">su: %s</string>
-    <string name="home_su_path_ex">su: %s -&gt; %s</string>
-    <string name="kpatch_shadow_path">kpatch: %s -&gt; %s</string>
+    <string name="kpatch_version">Version: %s</string>
+    <string name="apatch_version">Version: %s</string>
+    <string name="apatch_version_update">Version: %s -&gt; %s</string>
+    <string name="kpatch_version_update">Version: %s -&gt; %s</string>
+    <string name="home_su_path_title">su</string>
+    <string name="kpatch_shadow_path_title">kpatch</string>
     <string name="home_apatch_version">APatch: %s</string>
     <string name="home_auth_key_title">Enter SuperKey</string>
     <string name="home_auth_key_desc">Start after certification</string>
+    <string name="home_kpatch_info_title">Info</string>
+    <string name="home_superuser_count">Superusers: %d</string>
+    <string name="home_module_count">Modules: %d</string>
 
     <string name="home_ap_cando_install">Install</string>
     <string name="home_ap_cando_update">Update</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <string name="about">About</string>
     <string name="settings_app_language">Language</string>
     <string name="system_default">System default</string>
+    <string name="settings_global_namespace_mode">Global Namespace Mode</string>
+    <string name="settings_global_namespace_mode_summary">All root sessions use the global mount namespace</string>
 
     <string name="home_learn_apatch">Learn AndroidPatch</string>
     <string name="home_learn_android_patch_url">https://github.com/bmax121/APatch</string>

--- a/docs/cn/faq_cn.md
+++ b/docs/cn/faq_cn.md
@@ -45,4 +45,3 @@ KernelPatch 添加了一个新的系统调用（syscall），为应用程序和�
 
 - KernelPatch不修改SELinux上下文，而是通过hook绕过SELinux。 这允许您在应用程序上下文中root Android线程，无需使用libsu启动新进程，然后执行IPC。这非常方便。
 - 此外，APatch直接利用magiskpolicy提供额外的SELinux支持。  
-  但是，仅这样会被检测为Magisk。有兴趣的人可以尝试绕过，问题已经很明确。

--- a/docs/cn/faq_cn.md
+++ b/docs/cn/faq_cn.md
@@ -15,7 +15,7 @@ APatch分别结合了Magisk方便易用的通过`boot.img`安装的方法，和K
 
 ## APatch与Magisk、KernelSU的区别？
 
-- APatch可选择不修改SELinux。APatch还允许您在不创建新线程的情况下，在Android应用程序上下文中进行root，因此无需libsu和IPC。
+- APatch可选择不修改SELinux，这意味着Android应用程序线程可以被root，无需libsu和IPC。
 - APatch提供**Kernel Patch Module（KP模块）**。
 
 ## 什么是Kernel Patch Module（KP模块）？

--- a/docs/cn_tw/faq_cn_tw.md
+++ b/docs/cn_tw/faq_cn_tw.md
@@ -45,4 +45,3 @@ KernelPatch透過挂鉤系統調用提供所有功能給用戶空間，這個系
 - KernelPatch不修改SELinux上下文，透過挂鉤繞過SELinux，  
   這允許您在應用程式上下文中root Android線程，無需使用libsu啟動新進程，然後執行IPC。這非常方便。
 - 此外，APatch直接利用magiskpolicy提供額外的SELinux支援。  
-  但是，僅這樣會被檢測為Magisk。有興趣的人可以嘗試繞過，問題已經很明確。

--- a/docs/de/faq_de.md
+++ b/docs/de/faq_de.md
@@ -1,0 +1,49 @@
+# Häufig gestellte Fragen
+
+
+## Was ist APatch?
+APatch ist eine Root-Lösung, ähnlich wie Magisk oder KernelSU, welche das Beste beider vereint.
+Es kombiniert Magisks bequeme und leichte Installationsmethode über `boot.img` mit KernelSUs starken Kernel-Korrektur-Fähigkeiten.
+
+
+## Was ist der Unterschied zwischen APatch und Magisk?
+- Magisk modifiziert das Init-System mit einer Korrektur in Ihrem Startbild ramdisk, während APatch den Kernel direkt korrigiert.
+
+
+## APatch gegen KernelSU
+- KernelSU requires the source code for your device's kernel which is not always provided by the OEM. APatch works with just your stock `boot.img`.
+- KernelSU benötigt den Quellcode für dein Geräte-Kernel, welcher nicht immer von der OEM gegeben wird. APatch funktioniert allein mit Ihrem Standard-`boot.img`.
+
+## APatch gegen Magisk, KernelSU
+- APatch erlaubt Ihnen, optional, nicht SELinux zu modifizieren. Es erlaubt Ihnen auch, einen App-Thread zu rooten, ohne einen neuen au erstellen, sodass libsu und IPC nicht benötigt werden.
+- **Kernel Korrigtur Modul** gegeben.
+
+
+## Was ist ein Kernel Korrigtur Modul?
+Etwas Code läuft im Kernelbereich, ähnlich zu Ladbaren Kernel-Modulen (LKM).
+
+Dazu stellt KPM die Fähigkeit bereit, "inline-hook", "syscall-table-hook" im Kernelbereich zu machen.
+
+Für mehr Informationen, siehe [Wie schreibt man ein KPM](https://github.com/bmax121/KernelPatch/blob/main/doc/module.md)
+
+
+## Beziehung zwischen APatch und KernelPatch
+
+APatch benötigt KernelPatch, übernimmt all seine Fähigkeiten, und wurde erweitert.
+
+Sie können nur KernelPatch installieren, aber dies wird Ihnen nicht erlauben, Magisk-Module zu installieren, und um Superuserverwaltung zu nutzen, müssen Sie APatch installieren und es dann deinstallieren.
+[Lerne mehr über KernelPatch](https://github.com/bmax121/KernelPatch)
+
+
+## Was ist SuperKey?
+KernelPatch fügt einen neuen System-Abruf (syscall) hinzu, um alle Möglichkeiten, Apps und anderen Programmen im Benutzerbereich, bereitzustellen, dieser System-Abruf ist bekannt als **SuperCall**.
+Wenn eine App / ein Programm versucht\, **SuperCall** abzurufen, muss es ein Berechtigungsnachweis vorlegen, bekannt als **SuperKey**.
+**SuperCall** kann nur erfolgreich abgerufen werden, wenn der **SuperKey** korrekt ist und, wenn nicht, bleibt der Rufer unbetroffen.
+
+
+## Was ist mit SELinux?
+- KernelPatch bearbeitet den SELinux-Kontext nicht und umgeht den SELinux nicht über einen Haken.
+  Dies erlaubt Ihnen, einen Android-Thread in dem App-Kontext, ohne dem Gebrauch, libsu zu nutzen, um einen neuen Prozess zu starten und darruf IPC auszuführen, zu rooten.
+  Dies ist bequem.
+- Dazu verwendet APatch direkt das Magiskkonzept, um weiteren SELinux-Unterstützung bereitzustellen.
+  Jedoch wird nur dies als Magisk erkannt. Jeder Interessierter kann versuchen, dies zu umgehen, das Problem ist bereits recht klar.

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -29,9 +29,9 @@ For more information, see [How to write a KPM](https://github.com/bmax121/Kernel
 
 ## Relationship between APatch and KernelPatch
 
-APatch depends on KernelPatch, inherits all its capabilities, and has been expanded.  
+APatch depends on KernelPatch, inherits all its capabilities, and has been expanded.
 
-You can install KernelPatch only, but this will not allow you to use Magisk modules, and to use superuser management, you need to install AndroidPatch and then uninstall it.
+You can install KernelPatch only, but this will not allow you to use Magisk modules, and to use superuser management, you need to install APatch and then uninstall it.
 
 [Learn more about KernelPatch](https://github.com/bmax121/KernelPatch)
 
@@ -43,8 +43,8 @@ When an app/program tries to invoke **SuperCall**, it needs to provide an access
 
 
 ## How about SELinux?
-- KernelPatch don't modify the SELinux context and bypasses SELinux via a hook.
+- KernelPatch doesn't modify the SELinux context and bypasses SELinux via a hook.
   This allows you to root an Android thread within the app context without the need to use libsu to start a new process and then perform IPC.
   This is very convenient.
-- In addition, APatch directly utilizes magiskpolicy to provide additional SELinux support.  
+- In addition, APatch directly utilizes magiskpolicy to provide additional SELinux support.
   However, only this will be detected as Magisk. Anyone interested can try to bypass it, the issue is already quite clear.

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -47,4 +47,3 @@ When an app/program tries to invoke **SuperCall**, it needs to provide an access
   This allows you to root an Android thread within the app context without the need to use libsu to start a new process and then perform IPC.
   This is very convenient.
 - In addition, APatch directly utilizes magiskpolicy to provide additional SELinux support.
-  However, only this will be detected as Magisk sometimes.

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -31,7 +31,7 @@ For more information, see [How to write a KPM](https://github.com/bmax121/Kernel
 
 APatch depends on KernelPatch, inherits all its capabilities, and has been expanded.
 
-You can install KernelPatch only, but this will not allow you to use Magisk modules, and to use superuser management, you need to install APatch and then uninstall it.
+You can install KernelPatch only, but this will not allow you to use Magisk modules, and to use superuser management, you need to install AndroidPatch and then uninstall it.
 
 [Learn more about KernelPatch](https://github.com/bmax121/KernelPatch)
 

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -15,7 +15,7 @@ It combines Magisk's convenient and easy install method through `boot.img` with 
 
 
 ## APatch vs Magisk, KernelSU
-- APatch allows you to optionally not modify SELinux. It also allows you to root an app's thread without creating a new one, so libsu and IPC are not required.
+- APatch allows you to optionally not modify SELinux, this means that the APP thread can be rooted, libsu and IPC are not necessary.
 - **Kernel Patch Module** provided.
 
 
@@ -47,4 +47,4 @@ When an app/program tries to invoke **SuperCall**, it needs to provide an access
   This allows you to root an Android thread within the app context without the need to use libsu to start a new process and then perform IPC.
   This is very convenient.
 - In addition, APatch directly utilizes magiskpolicy to provide additional SELinux support.
-  However, only this will be detected as Magisk. Anyone interested can try to bypass it, the issue is already quite clear.
+  However, only this will be detected as Magisk sometimes.

--- a/docs/tr/faq_tr.md
+++ b/docs/tr/faq_tr.md
@@ -2,48 +2,45 @@
 
 ## APatch nedir?
 
-APatch, Magisk veya KernelSU'ya benzer bir root çözümdür ancak APatch daha fazlasını sunar.
+APatch, Magisk veya KernelSU'ya benzeyen ve her ikisinin de en iyi yönlerini birleştiren bir root çözümdür. Magisk'in boot.img aracılığıyla kullanışlı ve kolay kurulum yöntemini ve KernelSU'nun güçlü kernel yamalama yeteneklerini birleştirir.
 
 ## APatch vs Magisk
 
-- Magisk, init'i modifiye eder, APatch linux kernelini yamalar.
+- Magisk başlangıç sistemini kernel'in ramdisk'indeki bir yama ile değiştirirken; APatch kernel'i doğrudan yamalar.
 
 ## APatch vs KernelSU
 
-- KernelSU kaynak kodu gerektirir. APatch için sadece boot.img yeterlidir.
+- KernelSU, cihazınızın kernel'i için her zaman OEM tarafından sağlanmayan kaynak kodunu gerektirir. APatch yalnızca stok boot.img dosyanızla çalışır.
 
 ## APatch vs Magisk, KernelSU
 
-- İsteğe bağlı olarak SELinux'u değiştirmez. Android uygulaması bağlamında root, libsu ve IPC'ye gerek yoktur.
-- **Kernel Patch Modülü** sağlanır
+- İsteğe bağlı olarak SELinux'u değiştirmez. Bu şu anlama gelir; android uygulaması bağlamında root, libsu ve IPC'ye gerek yoktur.
+- **Kernel Patch Modülü** sağlanır.
 
 ## Kernel Patch Modülü nedir?
 
-Bazı kodlar, Yüklenebilir Çekirdek Modüllerinde (LKM) olduğu gibi Kernel Seviyesinde çalışır.
+Bazı kodlar, Yüklenebilir Kernel Modüllerinde (LKM) olduğu gibi Kernel Seviyesinde çalışır.
 
-Ek olarak KPM, çekirdek alanında satır içi kanca, sistem çağrısı-tablo kancası yapma yeteneği sağlar.
+Ek olarak KPM, kernel sviyesinde satır içi kanca, sistem çağrısı-tablo kancası yapma yeteneği sağlar.
 
 [KPM nasıl yazılır?](https://github.com/bmax121/KernelPatch/blob/main/doc/module.md)
 
 ## APatch and KernelPatch arasındaki ilişki
 
-APatch, KernelPatch'e bağımlıdır, onun tüm yeteneklerini devralır ve genişletilmiştir.
+APatch, KernelPatch'e dayalıdır; onun tüm yeteneklerini devralır ve onu daha da geliştirmiştir.
 
-Yalnızca KernelPatch'i kurabilirsiniz ancak bu, magisk modülünü kullanmanıza izin vermez,
-Superuser yönetimini kullanmak için AndroidPatch'i yüklemeniz ve ardından kaldırmanız gerekir.
+Yalnızca KernelPatch'i kurabilirsiniz ancak bu magisk modüllerini kullanmanıza izin vermez,
+Superuser yönetimini kullanmak için de AndroidPatch'i yüklemeniz ve ardından kaldırmanız gerekir.
 
 [KernelPatch hakkında daha fazlasını öğrenin](https://github.com/bmax121/KernelPatch)
 
 ## Super Anahtar nedir?
 
-KernelPatch, tüm yetenekleri kullanıcı alanına sağlamak için sistem çağrılarını kancalar ve bu sistem çağrısına **SuperCall** denir.  
+KernelPatch, tüm yetenekleri kullanıcı alanına (userspace) sağlamak için sistem çağrılarını kancalar ve bu sistem çağrısına **SuperCall** denir.  
 SuperCall'ı çağırmak, **Super Anahtar** olarak bilinen bir kimlik bilgisinin iletilmesini gerektirir.
 SuperCall yalnızca Super Anahtar doğru olduğunda başarılı bir şekilde çağrılabilir; Super Anahtar hatalıysa çağıran bundan etkilenmez.
 
 ## SELinux'a ne dersiniz?
 
-- KernelPatch, selinux içeriğini değiştirmez ve selinux'u kanca yoluyla atlamaz,
-  Bu, yeni bir işlem başlatmak ve ardından IPC gerçekleştirmek için libsu kullanmanıza gerek kalmadan, uygulama bağlamında bir Android iş parçacığını rootlamanıza olanak tanır.
-  Bu çok kullanışlıdır.
+- KernelPatch, SELinux içeriğini değiştirmez ve SELinux'u kanca yoluyla atlamaz. Bu, yeni bir işlem başlatmak ve ardından IPC gerçekleştirmek için libsu kullanmanıza gerek kalmadan, uygulama bağlamında bir Android iş parçacığını rootlamanıza olanak tanır. Bu çok kullanışlıdır.
 - Ayrıca APatch, ek SELinux desteği sağlamak için doğrudan magiskpolicy'yi kullanır.
-  Ancak yalnızca bu Magisk olarak algılanacaktır. İlgilenen herkes bunu atlamayı deneyebilir, sorun zaten oldukça açık.


### PR DESCRIPTION
Description:
- Add an update function of `KernelPatch` for direct installation when an update of `kpatch` is available
- Add an update button to the `KernelPatch`
- Update the `KernelPatch` card to have less information (more room for the new update button)
- Add superuser and module count information to the `KernelPatch` card similar to what `KernelSU` has
  - This is just to prevent having only the version information on this card, we can think of another (small) useful info to have here
- Add an Info dialog to keep the information of the `su` and `kpatch` paths that were previously in the card itself
  - This dialog can be opened by a click on the `KernelPatch` card
- Multiple small improvements ad typo fixes on the code overall

Demo (version file was changed manually to simulate a new update):
https://github.com/bmax121/APatch/assets/4687488/25e5a902-afb0-4fb6-9c77-98bcdaaafd71

