### PR TITLE
feat: update kernel on kpatch update and update Home screen

### DIFF
--- a/app/src/main/assets/util_functions.sh
+++ b/app/src/main/assets/util_functions.sh
@@ -58,3 +58,27 @@ find_boot_image() {
     BOOTIMAGE=$(grep -v '#' /etc/*fstab* | grep -E '/boot(img)?[^a-zA-Z]' | grep -oE '/dev/[a-zA-Z0-9_./-]*' | head -n 1)
   fi
 }
+
+flash_image() {
+  local CMD1
+  case "$1" in
+    *.gz) CMD1="gzip -d < '$1' 2>/dev/null";;
+    *)    CMD1="cat '$1'";;
+  esac
+  if [ -b "$2" ]; then
+    local img_sz=$(stat -c '%s' "$1")
+    local blk_sz=$(blockdev --getsize64 "$2")
+    [ "$img_sz" -gt "$blk_sz" ] && return 1
+    blockdev --setrw "$2"
+    local blk_ro=$(blockdev --getro "$2")
+    [ "$blk_ro" -eq 1 ] && return 2
+    eval "$CMD1" | cat - /dev/zero > "$2" 2>/dev/null
+  elif [ -c "$2" ]; then
+    flash_eraseall "$2" >&2
+    eval "$CMD1" | nandwrite -p "$2" - >&2
+  else
+    echo "- Not block or char device, storing image"
+    eval "$CMD1" > "$2" 2>/dev/null
+  fi
+  return 0
+}

--- a/app/src/main/java/me/bmax/apatch/APatchApp.kt
+++ b/app/src/main/java/me/bmax/apatch/APatchApp.kt
@@ -78,9 +78,7 @@ class APApplication : Application() {
         var aPatchVersion: Int = 0
 
         fun installKpatch() {
-            if (_kpStateLiveData.value != State.KERNELPATCH_NEED_UPDATE) {
-                return
-            }
+            if (_kpStateLiveData.value != State.KERNELPATCH_NEED_UPDATE) return
 
             kPatchVersion = getKPatchVersion()
 

--- a/app/src/main/java/me/bmax/apatch/APatchApp.kt
+++ b/app/src/main/java/me/bmax/apatch/APatchApp.kt
@@ -222,6 +222,18 @@ class APApplication : Application() {
                         Log.e(TAG, "su failed: " + rc)
                         return@thread
                     }
+                    
+                    // Ensure migration scenario temporarily
+                    var tmp = File(APATCH_FLODER + "version")
+                    if (tmp.exists()) {
+                        val version = tmp.readLines().get(0).toInt()
+                        tmp.delete()
+                        File(APATCH_VERSION_PATH).writeText(version.toString())
+                        tmp = File(KPATCH_VERSION_PATH)
+                        if (!tmp.exists()) {
+                            File(KPATCH_VERSION_PATH).writeText(getKernelPatchVersion())
+                        }
+                    }
 
                     val kv = File(KPATCH_VERSION_PATH)
                     val kvn = getKPatchVersion()

--- a/app/src/main/java/me/bmax/apatch/Natives.kt
+++ b/app/src/main/java/me/bmax/apatch/Natives.kt
@@ -58,7 +58,7 @@ object Natives {
     }
 
     private external fun nativeKernelPatchVersion(superKey: String): Long
-    fun kerenlPatchVersion(): Long {
+    fun kernelPatchVersion(): Long {
         return nativeKernelPatchVersion(APApplication.superKey)
     }
     private external fun nativeLoadKernelPatchModule(superKey: String, modulePath: String, args: String): Long

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
@@ -410,7 +410,7 @@ private fun KStatusCard(kpState: APApplication.State, navigator: DestinationsNav
                         )
                     }
                 }
-                if (kpState.equals(APApplication.State.KERNELPATCH_NEED_UPDATE)) {
+                if (kpState.equals(APApplication.State.KERNELPATCH_NEED_UPDATE) && isDirectInstallAvailable()) {
                     Column (modifier = Modifier
                         .align(Alignment.CenterVertically)
                     ) {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
@@ -53,7 +53,7 @@ import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import dev.utils.app.permission.PermissionUtils
 import dev.utils.app.permission.PermissionUtils.PermissionCallback
-import me.bmax.apatch.util.getSELinuxStatus
+import me.bmax.apatch.util.*
 import me.bmax.apatch.*
 import me.bmax.apatch.R
 import me.bmax.apatch.ui.component.ConfirmDialog
@@ -65,7 +65,8 @@ import me.bmax.apatch.ui.screen.destinations.SettingScreenDestination
 @Destination
 @Composable
 fun HomeScreen(navigator: DestinationsNavigator) {
-    val state by APApplication.apStateLiveData.observeAsState(APApplication.State.UNKNOWN_STATE)
+    val kpState by APApplication.kpStateLiveData.observeAsState(APApplication.State.UNKNOWN_STATE)
+    val apState by APApplication.apStateLiveData.observeAsState(APApplication.State.UNKNOWN_STATE)
 
     Scaffold(topBar = {
         TopBar(onSettingsClick = {
@@ -84,8 +85,8 @@ fun HomeScreen(navigator: DestinationsNavigator) {
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             WarningCard()
-            KStatusCard(state)
-            AStatusCard(state, navigator)
+            KStatusCard(kpState, navigator)
+            AStatusCard(apState)
             InfoCard()
             LearnMoreCard()
             Spacer(Modifier)
@@ -209,7 +210,7 @@ fun StartPatch(showDialog: MutableState<Boolean>, navigator: DestinationsNavigat
 
 @Composable
 fun FloatButton(navigator: DestinationsNavigator) {
-    val state by APApplication.apStateLiveData.observeAsState(APApplication.State.UNKNOWN_STATE)
+    val apState by APApplication.apStateLiveData.observeAsState(APApplication.State.UNKNOWN_STATE)
 
     var showAuthKeyDialog = remember { mutableStateOf(false)  }
     var showSetKeyDialog = remember { mutableStateOf(false)  }
@@ -219,7 +220,7 @@ fun FloatButton(navigator: DestinationsNavigator) {
         AuthSuperKey(showDialog = showAuthKeyDialog)
     }
 
-    if(permissionRequest.value) {
+    if (permissionRequest.value) {
         PermissionUtils.permission(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
             .callback( object : PermissionCallback{
                 override fun onGranted() {
@@ -237,7 +238,7 @@ fun FloatButton(navigator: DestinationsNavigator) {
             .request(LocalContext.current as Activity)
     }
 
-    if(showSetKeyDialog.value) {
+    if (showSetKeyDialog.value) {
         StartPatch(showDialog = showSetKeyDialog, navigator)
     }
 
@@ -259,7 +260,7 @@ fun FloatButton(navigator: DestinationsNavigator) {
         Box() {
             ExtendedFloatingActionButton(
                 onClick = {
-                    if(state != APApplication.State.UNKNOWN_STATE) {
+                    if (apState != APApplication.State.UNKNOWN_STATE) {
                         apApp.updateSuperKey("")
                     } else {
                         showAuthKeyDialog.value = true
@@ -268,7 +269,7 @@ fun FloatButton(navigator: DestinationsNavigator) {
                 icon = { Icon(Icons.Filled.Key, "") },
                 text = {
                     Text(
-                        text = if (state != APApplication.State.UNKNOWN_STATE) {
+                        text = if (apState != APApplication.State.UNKNOWN_STATE) {
                             stringResource(id = R.string.clear_super_key)
                         } else {
                             stringResource(id = R.string.super_key)
@@ -328,82 +329,25 @@ private fun TopBar(onSettingsClick: () -> Unit) {
     })
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun KStatusCard(state: APApplication.State) {
+private fun KStatusCard(kpState: APApplication.State, navigator: DestinationsNavigator) {
+    val showInfoDialog = remember { mutableStateOf(false) }
+    if (showInfoDialog.value) {
+        InfoDialog(showDialog = showInfoDialog)
+    }
     ElevatedCard(
+        onClick = { showInfoDialog.value = true },
         colors = CardDefaults.elevatedCardColors(containerColor = run {
             MaterialTheme.colorScheme.secondaryContainer
         })
     ) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(12.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp), horizontalAlignment = Alignment.CenterHorizontally) {
             Row {
                 Text(text = stringResource(R.string.kernel_patch),
-                    style = MaterialTheme.typography.titleMedium
-                )
-            }
-            Row(modifier = Modifier
-                .fillMaxWidth()
-                .padding(10.dp), verticalAlignment = Alignment.CenterVertically) {
-                when {
-                    !state.equals(APApplication.State.UNKNOWN_STATE) -> {
-                        val kernelPatchVersion = Natives.kerenlPatchVersion()
-                        Icon(Icons.Outlined.CheckCircle, stringResource(R.string.home_working))
-                        Column(Modifier.padding(start = 16.dp)) {
-                            Text(text = stringResource(R.string.home_working),
-                                style = MaterialTheme.typography.titleMedium
-                            )
-                            Spacer(Modifier.height(6.dp))
-                            Text(text = stringResource(R.string.kpatch_version, kernelPatchVersion.and(0xff0000).shr(16),
-                                    kernelPatchVersion.and(0xff00).shr(8), kernelPatchVersion.and(0xff)),
-                                style = MaterialTheme.typography.bodyMedium
-                            )
-                            Spacer(Modifier.height(6.dp))
-                            when {
-                                state.equals(APApplication.State.ANDROIDPATCH_INSTALLED) || state.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
-                                    Text(text = stringResource(R.string.home_su_path_ex, Natives.suPath(), APApplication.APD_PATH),
-                                        style = MaterialTheme.typography.bodyMedium
-                                    )
-                                    Spacer(Modifier.height(6.dp))
-                                    Text(text = stringResource(R.string.kpatch_shadow_path, APApplication.KPATCH_SHADOW_PATH, APApplication.KPATCH_PATH),
-                                        style = MaterialTheme.typography.bodyMedium
-                                    )
-                                }
-                                !state.equals(APApplication.State.UNKNOWN_STATE) -> {
-                                    Text(text = stringResource(R.string.home_su_path, Natives.suPath()),
-                                        style = MaterialTheme.typography.bodyMedium
-                                    )
-                                }
-                            }
-                        }
-                    }
-                    else -> {
-                        Icon(Icons.Outlined.Block, stringResource(R.string.home_install_unknown))
-                        Column(Modifier.padding(start = 16.dp)) {
-                            Text(text = stringResource(R.string.home_install_unknown),
-                                style = MaterialTheme.typography.titleMedium
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun AStatusCard(state: APApplication.State, navigator: DestinationsNavigator) {
-    ElevatedCard(
-        colors = CardDefaults.elevatedCardColors(containerColor = run {
-            MaterialTheme.colorScheme.secondaryContainer
-        })
-    ) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(12.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-            Row {
-                Text(text = stringResource(R.string.android_patch),
                     style = MaterialTheme.typography.titleMedium
                 )
             }
@@ -412,16 +356,10 @@ private fun AStatusCard(state: APApplication.State, navigator: DestinationsNavig
                     .fillMaxWidth()
                     .padding(10.dp), verticalAlignment = Alignment.CenterVertically) {
                 when {
-                    state.equals(APApplication.State.KERNELPATCH_READY) -> {
-                        Icon(Icons.Outlined.Block, stringResource(R.string.home_not_installed))
-                    }
-                    state.equals(APApplication.State.ANDROIDPATCH_INSTALLING) -> {
-                        Icon(Icons.Outlined.InstallMobile, stringResource(R.string.home_installing))
-                    }
-                    state.equals(APApplication.State.ANDROIDPATCH_INSTALLED) -> {
+                    kpState.equals(APApplication.State.KERNELPATCH_INSTALLED) -> {
                         Icon(Icons.Outlined.CheckCircle, stringResource(R.string.home_working))
                     }
-                    state.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
+                    kpState.equals(APApplication.State.KERNELPATCH_NEED_UPDATE) -> {
                         Icon(Icons.Outlined.SystemUpdate, stringResource(R.string.home_need_update))
                     }
                     else -> {
@@ -433,35 +371,181 @@ private fun AStatusCard(state: APApplication.State, navigator: DestinationsNavig
                         .weight(2f)
                         .padding(start = 16.dp)
                 ) {
-                    val managerVersion = getManagerVersion()
                     when {
-                        state.equals(APApplication.State.KERNELPATCH_READY) -> {
-                            Text(text = stringResource(R.string.home_not_installed),
-                                style = MaterialTheme.typography.titleMedium
-                            )
-                        }
-                        state.equals(APApplication.State.ANDROIDPATCH_INSTALLING) -> {
-                            Text(text = stringResource(R.string.home_installing),
-                                style = MaterialTheme.typography.titleMedium
-                            )
-                        }
-                        state.equals(APApplication.State.ANDROIDPATCH_INSTALLED) -> {
+                        kpState.equals(APApplication.State.KERNELPATCH_INSTALLED) -> {
                             Text(text = stringResource(R.string.home_working),
                                 style = MaterialTheme.typography.titleMedium
                             )
                             Spacer(Modifier.height(6.dp))
-                            Text(text = stringResource(R.string.apatch_version,
-                                "${managerVersion.first} (${managerVersion.second})"),
+                            Text(text = stringResource(R.string.kpatch_version, APApplication.kPatchVersion),
                                 style = MaterialTheme.typography.bodyMedium
                             )
                         }
-                        state.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
+                        kpState.equals(APApplication.State.KERNELPATCH_NEED_UPDATE) -> {
                             Text(text = stringResource(R.string.home_need_update),
                                 style = MaterialTheme.typography.titleMedium
                             )
                             Spacer(Modifier.height(6.dp))
-                            Text(text = stringResource(R.string.apatch_version_update, "${APApplication.apatchVersion}",
-                                "${managerVersion.first} (${managerVersion.second})"),
+                            Text(text = stringResource(R.string.kpatch_version_update, APApplication.kPatchVersion, getKPatchVersion()),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                        else -> {
+                            Text(text = stringResource(R.string.home_install_unknown),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                        }
+                    }
+                    if (!kpState.equals(APApplication.State.UNKNOWN_STATE)) {
+                        Spacer(Modifier.height(4.dp))
+                        Text(text = stringResource(R.string.home_superuser_count, getSuperuserCount()),
+                             style = MaterialTheme.typography.bodyMedium
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(text = stringResource(R.string.home_module_count, getModuleCount()),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+                if (kpState.equals(APApplication.State.KERNELPATCH_NEED_UPDATE)) {
+                    Column (modifier = Modifier
+                        .align(Alignment.CenterVertically)
+                    ) {
+                        Button(
+                            onClick = {
+                                APApplication.installKpatch()
+                                navigator.navigate(PatchScreenDestination(null, apApp.getSuperKey()))
+                            },
+                            content = {
+                                Text(text = stringResource(id = R.string.home_ap_cando_update), color = Color.Black)
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun InfoDialog(showDialog: MutableState<Boolean>) {
+    val apState by APApplication.apStateLiveData.observeAsState(APApplication.State.UNKNOWN_STATE)
+
+    AlertDialog(
+        onDismissRequest = { showDialog.value = false },
+        title = { Text(stringResource(id = R.string.home_kpatch_info_title)) },
+        text = {
+            Column {
+                Text(text = stringResource(R.string.home_su_path_title),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                when {
+                    apState.equals(APApplication.State.ANDROIDPATCH_INSTALLED) ||
+                    apState.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
+                        val suPath = "%s -> %s".format(Natives.suPath(), APApplication.APD_PATH)
+                        Text(text = suPath,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+
+                        Spacer(Modifier.height(16.dp))
+                        Text(text = stringResource(R.string.kpatch_shadow_path_title),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        val kpPath = "%s -> %s".format(APApplication.KPATCH_SHADOW_PATH, APApplication.KPATCH_PATH)
+                        Text(text = kpPath,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                    else -> {
+                        val suPath = "%s".format(Natives.suPath())
+                        Text(text = suPath,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    showDialog.value = false
+                }
+            ) {
+                Text(stringResource(id = android.R.string.ok))
+            }
+        }
+    )
+}
+
+@Composable
+private fun AStatusCard(apState: APApplication.State) {
+    ElevatedCard(
+        colors = CardDefaults.elevatedCardColors(containerColor = run {
+            MaterialTheme.colorScheme.secondaryContainer
+        })
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+            Row {
+                Text(text = stringResource(R.string.android_patch),
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(10.dp), verticalAlignment = Alignment.CenterVertically) {
+                when {
+                    apState.equals(APApplication.State.ANDROIDPATCH_READY) -> {
+                        Icon(Icons.Outlined.Block, stringResource(R.string.home_not_installed))
+                    }
+                    apState.equals(APApplication.State.ANDROIDPATCH_INSTALLING) -> {
+                        Icon(Icons.Outlined.InstallMobile, stringResource(R.string.home_installing))
+                    }
+                    apState.equals(APApplication.State.ANDROIDPATCH_INSTALLED) -> {
+                        Icon(Icons.Outlined.CheckCircle, stringResource(R.string.home_working))
+                    }
+                    apState.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
+                        Icon(Icons.Outlined.SystemUpdate, stringResource(R.string.home_need_update))
+                    }
+                    else -> {
+                        Icon(Icons.Outlined.Block, stringResource(R.string.home_install_unknown))
+                    }
+                }
+                Column(
+                    Modifier
+                        .weight(2f)
+                        .padding(start = 16.dp)
+                ) {
+                    val managerVersion = APApplication.getManagerVersion()
+                    when {
+                        apState.equals(APApplication.State.ANDROIDPATCH_READY) -> {
+                            Text(text = stringResource(R.string.home_not_installed),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                        }
+                        apState.equals(APApplication.State.ANDROIDPATCH_INSTALLING) -> {
+                            Text(text = stringResource(R.string.home_installing),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                        }
+                        apState.equals(APApplication.State.ANDROIDPATCH_INSTALLED) -> {
+                            Text(text = stringResource(R.string.home_working),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Spacer(Modifier.height(6.dp))
+                            Text(text = stringResource(R.string.apatch_version, managerVersion.second),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                        apState.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
+                            Text(text = stringResource(R.string.home_need_update),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Spacer(Modifier.height(6.dp))
+                            Text(text = stringResource(R.string.apatch_version_update, APApplication.aPatchVersion, managerVersion.second),
                                 style = MaterialTheme.typography.bodyMedium
                             )
                         }
@@ -472,41 +556,35 @@ private fun AStatusCard(state: APApplication.State, navigator: DestinationsNavig
                         }
                     }
                 }
-                if(!state.equals(APApplication.State.UNKNOWN_STATE)) {
+                if (!apState.equals(APApplication.State.UNKNOWN_STATE)) {
                     Column (modifier = Modifier
                         .align(Alignment.CenterVertically)
                     ) {
                         Button(
                             onClick = {
                                 when {
-                                    state.equals(APApplication.State.KERNELPATCH_READY)
-                                            || state.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
-                                        APApplication.install()
-//                                        if (state.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE)) {
-//                                            navigator.navigate(PatchScreenDestination(null, apApp.getSuperKey()))
-//                                        }
-                                    }
-                                    state.equals(APApplication.State.ANDROIDPATCH_INSTALLED) -> {
-                                        APApplication.uninstall()
+                                    apState.equals(APApplication.State.ANDROIDPATCH_READY) ||
+                                    apState.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
+                                        APApplication.installApatch()
                                     }
                                     else -> {
-
+                                        APApplication.uninstallApatch()
                                     }
                                 }
                             },
                             content = {
                                 when {
-                                    state.equals(APApplication.State.KERNELPATCH_READY) -> {
+                                    apState.equals(APApplication.State.ANDROIDPATCH_READY) -> {
                                         Text(text = stringResource(id = R.string.home_ap_cando_install), color = Color.Black)
                                     }
-                                    state.equals(APApplication.State.ANDROIDPATCH_UNINSTALLING)
-                                            || state.equals(APApplication.State.ANDROIDPATCH_UNINSTALLING) -> {
+                                    apState.equals(APApplication.State.ANDROIDPATCH_UNINSTALLING) ||
+                                    apState.equals(APApplication.State.ANDROIDPATCH_UNINSTALLING) -> {
                                         Icon(Icons.Outlined.Cached, contentDescription = "busy")
                                     }
-                                    state.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
+                                    apState.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
                                         Text(text = stringResource(id = R.string.home_ap_cando_update), color = Color.Black)
                                     }
-                                    state.equals(APApplication.State.ANDROIDPATCH_INSTALLED) -> {
+                                    apState.equals(APApplication.State.ANDROIDPATCH_INSTALLED) -> {
                                         Text(text = stringResource(id = R.string.home_ap_cando_uninstall), color = Color.Black)
                                     }
                                 }
@@ -523,7 +601,7 @@ private fun AStatusCard(state: APApplication.State, navigator: DestinationsNavig
 @Composable
 fun WarningCard() {
     var show by rememberSaveable { mutableStateOf(apApp.getBackupWarningState()) }
-    if(show) {
+    if (show) {
         ElevatedCard(
             colors = CardDefaults.elevatedCardColors(containerColor = run {
                 MaterialTheme.colorScheme.error
@@ -631,10 +709,4 @@ fun LearnMoreCard() {
             }
         }
     }
-}
-
-
-fun getManagerVersion(): Pair<String, Int> {
-    val packageInfo = apApp.packageManager.getPackageInfo(apApp.packageName, 0)
-    return Pair(packageInfo.versionName, packageInfo.versionCode)
 }

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
@@ -577,14 +577,13 @@ private fun AStatusCard(apState: APApplication.State) {
                                     apState.equals(APApplication.State.ANDROIDPATCH_READY) -> {
                                         Text(text = stringResource(id = R.string.home_ap_cando_install), color = Color.Black)
                                     }
-                                    apState.equals(APApplication.State.ANDROIDPATCH_UNINSTALLING) ||
                                     apState.equals(APApplication.State.ANDROIDPATCH_UNINSTALLING) -> {
                                         Icon(Icons.Outlined.Cached, contentDescription = "busy")
                                     }
                                     apState.equals(APApplication.State.ANDROIDPATCH_NEED_UPDATE) -> {
                                         Text(text = stringResource(id = R.string.home_ap_cando_update), color = Color.Black)
                                     }
-                                    apState.equals(APApplication.State.ANDROIDPATCH_INSTALLED) -> {
+                                    else -> {
                                         Text(text = stringResource(id = R.string.home_ap_cando_uninstall), color = Color.Black)
                                     }
                                 }

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
@@ -377,7 +377,10 @@ private fun KStatusCard(kpState: APApplication.State, navigator: DestinationsNav
                                 style = MaterialTheme.typography.titleMedium
                             )
                             Spacer(Modifier.height(6.dp))
-                            Text(text = stringResource(R.string.kpatch_version, APApplication.kPatchVersion),
+                            // Ensure it doesnt crash on non-updated translations
+                            var tmp = stringResource(R.string.kpatch_version)
+                            tmp = tmp.replace("%d.%d.%d", "%s")
+                            Text(text = tmp.format(APApplication.kPatchVersion),
                                 style = MaterialTheme.typography.bodyMedium
                             )
                         }

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
@@ -22,8 +22,6 @@ import androidx.compose.ui.unit.dp
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.topjohnwu.superuser.CallbackList
-import com.topjohnwu.superuser.Shell
-import com.topjohnwu.superuser.ShellUtils
 import com.topjohnwu.superuser.nio.ExtendedFile
 import com.topjohnwu.superuser.nio.FileSystemManager
 import dev.utils.app.MediaStoreUtils
@@ -35,7 +33,7 @@ import me.bmax.apatch.R
 import me.bmax.apatch.TAG
 import me.bmax.apatch.APApplication
 import me.bmax.apatch.apApp
-import me.bmax.apatch.util.reboot
+import me.bmax.apatch.util.*
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -149,10 +147,6 @@ fun InputStream.writeTo(file: File) = copyAndClose(file.outputStream())
 
 private fun InputStream.copyAndCloseOut(out: OutputStream) = out.use { copyTo(it) }
 
-private val shell = Shell.getShell()
-private fun String.fsh() = ShellUtils.fastCmd(shell, this)
-private fun Array<String>.fsh() = ShellUtils.fastCmd(shell, *this)
-
 fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolean {
     var outPath: File? = null
     var srcBoot: ExtendedFile? = null
@@ -203,6 +197,7 @@ fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolea
         "cd $patchDir",
         patchCommand,
     )
+    val shell = getRootShell()
     shell.newJob().add(*cmds).to(logs, logs).exec()
     logs.add("****************************")
 

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
@@ -241,3 +241,9 @@ fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolea
 
     return succ
 }
+
+fun isDirectInstallAvailable(): Boolean {
+    val backupDir: ExtendedFile = FileSystemManager.getLocal().getFile(apApp.filesDir.parent, "backup")
+    val origBoot = backupDir.getChildFile("boot.img")
+    return origBoot.exists()
+}

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
@@ -156,7 +156,7 @@ private fun Array<String>.fsh() = ShellUtils.fastCmd(shell, *this)
 fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolean {
     var outPath: File? = null
     var srcBoot: ExtendedFile? = null
-    var patchDir: ExtendedFile = FileSystemManager.getLocal().getFile(apApp.filesDir.parent, "patch")
+    val patchDir: ExtendedFile = FileSystemManager.getLocal().getFile(apApp.filesDir.parent, "patch")
     patchDir.deleteRecursively()
     patchDir.mkdirs()
 

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
@@ -149,11 +149,9 @@ fun InputStream.writeTo(file: File) = copyAndClose(file.outputStream())
 
 private fun InputStream.copyAndCloseOut(out: OutputStream) = out.use { copyTo(it) }
 
-
 private val shell = Shell.getShell()
 private fun String.fsh() = ShellUtils.fastCmd(shell, this)
 private fun Array<String>.fsh() = ShellUtils.fastCmd(shell, *this)
-
 
 fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolean {
     var outPath: File? = null
@@ -205,20 +203,15 @@ fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolea
         "cd $patchDir",
         patchCommand,
     )
-    val isSuccess = shell.newJob().add(*cmds).to(logs, logs).exec().isSuccess
+    shell.newJob().add(*cmds).to(logs, logs).exec()
     logs.add("****************************")
 
     var succ = true
-    if (uri == null) {
-        if (isSuccess) {
+    val newBootFile = patchDir.getChildFile("new-boot.img")
+    if (newBootFile.exists()) {
+        if (uri == null) {
             logs.add(" Boot patch was successful")
         } else {
-            succ = false
-            logs.add(" Boot patch failed")
-        }
-    } else {
-        val newBootFile = patchDir.getChildFile("new-boot.img")
-        if (newBootFile.exists()) {
             val outDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
             if(!outDir.exists()) outDir.mkdirs()
             outPath = File(outDir, outFilename)
@@ -239,10 +232,10 @@ fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolea
             } else {
                 logs.add(" Write patched boot.img failed")
             }
-        } else {
-            succ = false
-            logs.add(" Patch failed, no new-boot.img generated")
         }
+    } else {
+        succ = false
+        logs.add(" Patch failed, no new-boot.img generated")
     }
     logs.add("****************************")
 

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Patch.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.bmax.apatch.R
 import me.bmax.apatch.TAG
+import me.bmax.apatch.APApplication
 import me.bmax.apatch.apApp
 import me.bmax.apatch.util.reboot
 import java.io.File
@@ -195,7 +196,7 @@ fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolea
         apApp.assets.open(script).writeTo(dest)
     }
 
-    val apVer = getManagerVersion().second
+    val apVer = APApplication.getManagerVersion().second
     val rand = (1..4).map { ('a'..'z').random() }.joinToString("")
     val outFilename = "apatch_${apVer}_${rand}_boot.img"
     val patchCommand = if (uri != null) "sh boot_patch.sh $superKey ${srcBoot?.path}" else "sh boot_patch.sh $superKey"
@@ -230,7 +231,7 @@ fun patchBootimg(uri: Uri?, superKey: String, logs: MutableList<String>): Boolea
             } else {
                 newBootFile.inputStream().copyAndClose(outPath.outputStream())
             }
-            
+
             if (succ) {
                 logs.add(" Write patched boot.img was successful")
                 logs.add(" Output file is written to ")

--- a/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
+++ b/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
@@ -67,6 +67,11 @@ fun createRootShellForLog(): Shell {
     }
 }
 
+fun execKpatch(args: String): Boolean {
+    val shell = getRootShell()
+    return ShellUtils.fastCmdResult(shell, "${APApplication.KPATCH_PATH} $args")
+}
+
 fun execApd(args: String): Boolean {
     val shell = getRootShell()
     return ShellUtils.fastCmdResult(shell, "${APApplication.APD_PATH} $args")
@@ -85,6 +90,12 @@ fun getModuleCount(): Int {
         val array = JSONArray(result)
         return array.length()
     }.getOrElse { return 0 }
+}
+
+fun getSuperuserCount(): Int {
+    val shell = getRootShell()
+    val out = shell.newJob().add("${APApplication.KPATCH_PATH} ${APApplication.superKey} sumgr num").to(ArrayList(), null).exec().out
+    return out[0].toIntOrNull() ?: 0
 }
 
 fun toggleModule(id: String, enable: Boolean): Boolean {
@@ -200,4 +211,16 @@ fun launchApp(packageName: String) {
 fun restartApp(packageName: String) {
     forceStopApp(packageName)
     launchApp(packageName)
+}
+
+fun getKPatchVersion(): String {
+    val shell = getRootShell()
+    val out = shell.newJob().add("${APApplication.KPATCH_PATH} -v").to(ArrayList(), null).exec().out
+    val outInt = out[0].toIntOrNull() ?: 0
+    val kernelPatchVersion = Integer.decode("0x${outInt}")
+    return "%d.%d.%d".format(
+        kernelPatchVersion.and(0xff0000).shr(16),
+        kernelPatchVersion.and(0xff00).shr(8),
+        kernelPatchVersion.and(0xff)
+    )
 }

--- a/app/src/main/java/me/bmax/apatch/util/LogEvent.kt
+++ b/app/src/main/java/me/bmax/apatch/util/LogEvent.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.os.Build
 import android.system.Os
 import com.topjohnwu.superuser.ShellUtils
+import me.bmax.apatch.APApplication
 import me.bmax.apatch.Natives
-import me.bmax.apatch.ui.screen.getManagerVersion
 import java.io.File
 import java.io.FileWriter
 import java.io.PrintWriter
@@ -62,7 +62,7 @@ fun getBugreportFile(context: Context): File {
         pw.println("PREVIEW_SDK: " + Build.VERSION.PREVIEW_SDK_INT)
         pw.println("FINGERPRINT: " + Build.FINGERPRINT)
         pw.println("DEVICE: " + Build.DEVICE)
-        pw.println("Manager: " + getManagerVersion())
+        pw.println("Manager: " + APApplication.getManagerVersion())
         pw.println("SELinux: $selinux")
 
         val uname = Os.uname()
@@ -72,8 +72,8 @@ fun getBugreportFile(context: Context): File {
         pw.println("Nodename: ${uname.nodename}")
         pw.println("Sysname: ${uname.sysname}")
 
-        pw.println("KPatch: ${Natives.kerenlPatchVersion()}")
-        pw.println("APatch: ${getManagerVersion()}")
+        pw.println("KPatch: ${APApplication.getKernelPatchVersion()}")
+        pw.println("APatch: ${APApplication.getManagerVersion()}")
         val safeMode = false
         pw.println("SafeMode: $safeMode")
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,15 +41,18 @@
     <string name="home_working">Working</string>
     <string name="home_installing">Installing</string>
     <string name="home_need_update">New version available</string>
-    <string name="kpatch_version">Version: %d.%d.%d</string>
-    <string name="apatch_version">Version:\n%s</string>
-    <string name="apatch_version_update">Version:\n%s -&gt; %s</string>
-    <string name="home_su_path">su: %s</string>
-    <string name="home_su_path_ex">su: %s -&gt; %s</string>
-    <string name="kpatch_shadow_path">kpatch: %s -&gt; %s</string>
+    <string name="kpatch_version">Version: %s</string>
+    <string name="apatch_version">Version: %s</string>
+    <string name="apatch_version_update">Version: %s -&gt; %s</string>
+    <string name="kpatch_version_update">Version: %s -&gt; %s</string>
+    <string name="home_su_path_title">su</string>
+    <string name="kpatch_shadow_path_title">kpatch</string>
     <string name="home_apatch_version">APatch: %s</string>
     <string name="home_auth_key_title">Enter SuperKey</string>
     <string name="home_auth_key_desc">Start after certification</string>
+    <string name="home_kpatch_info_title">Info</string>
+    <string name="home_superuser_count">Superusers: %d</string>
+    <string name="home_module_count">Modules: %d</string>
 
     <string name="home_ap_cando_install">Install</string>
     <string name="home_ap_cando_update">Update</string>


### PR DESCRIPTION
Description:
- Add an update function of `KernelPatch` for direct installation when an update of `kpatch` is available
- Add an update button to the `KernelPatch`
- Update the `KernelPatch` card to have less information (more room for the new update button)
- Add superuser and module count information to the `KernelPatch` card similar to what `KernelSU` has
    - This is just to prevent having only the version information on this card, we can think of another (small) useful info to have here
- Add an Info dialog to keep the information of the `su` and `kpatch` paths that were previously in the card itself
    - This dialog can be opened by a click on the `KernelPatch` card
- Multiple small improvements ad typo fixes on the code overall

Demo (version file was changed manually to simulate a new update):
https://github.com/bmax121/APatch/assets/4687488/563fa98a-de8c-4d39-adb9-0f96140a705c