### PR TITLE
Update APatchCli.kt

### DIFF
--- a/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
+++ b/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
@@ -29,9 +29,7 @@ fun getRootShell(): Shell {
 
 fun createRootShell(): Shell {
     Shell.enableVerboseLogging = BuildConfig.DEBUG
-    val builder = Shell.Builder.create().apply {
-        setFlags(Shell.FLAG_MOUNT_MASTER)
-    }
+    val builder = Shell.Builder.create()
     return try {
         builder.build(
             getKPatchPath(),

--- a/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
+++ b/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
@@ -171,14 +171,14 @@ fun hasMagisk(): Boolean {
 fun isGlobalNamespaceEnabled(): Boolean {
     val shell = getRootShell()
     val result =
-        ShellUtils.fastCmd(shell, "nsenter --mount=/proc/1/ns/mnt cat ${APApplication.GLOBAL_NAMESPACE_FILE}")
+        ShellUtils.fastCmd(shell, "cat ${APApplication.GLOBAL_NAMESPACE_FILE}")
     Log.i(TAG, "is global namespace enabled: $result")
     return result == "1"
 }
 
 fun setGlobalNamespaceEnabled(value: String) {
     getRootShell().newJob()
-        .add("nsenter --mount=/proc/1/ns/mnt echo $value > ${APApplication.GLOBAL_NAMESPACE_FILE}")
+        .add("echo $value > ${APApplication.GLOBAL_NAMESPACE_FILE}")
         .submit { result ->
             Log.i(TAG, "setGlobalNamespaceEnabled result: ${result.isSuccess} [${result.out}]")
         }


### PR DESCRIPTION
Removed FLAG_MOUNT_MASTER

ℹ️ Notice for users utilizing the _Global Namespace Mode_ setting: This change may bring back the bug that prevents the toggle from appearing active; however, this does not mean that the functionality is inactive. 
As long as the file `/data/adb/.global_namespace_enable` is present and contains the value `1`, it will work regardless of how the toggle is displayed.