### PR TITLE
Change the Chinese language names in the language picker to the most suitable character for Chinese expression habits

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -25,8 +25,8 @@
         <item>සිංහල</item>
         <item>ไทย</item>
         <item>日本語</item>
-        <item>粤语(简体)</item>
-        <item>粵語(繁體)</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
     </string-array>
 
     <string-array name="languages_values">


### PR DESCRIPTION
The names of "粤语（简体）" and "粤语（繁体）" in the current language picker are not expressed appropriately. The original term "粤语" refers only to one dialect among Simplified Chinese. The correct expressions should be "简体中文"  and "繁体中文". Hoping that you can merge my commit, making APatch better.