### PR TITLE
magisk: 26.4.4 -> 27.0

### DIFF
--- a/apd/src/installer.sh
+++ b/apd/src/installer.sh
@@ -437,5 +437,5 @@ POSTFSDATAD=$NVBASE/post-fs-data.d
 SERVICED=$NVBASE/service.d
 
 # Some modules dependents on this
-export MAGISK_VER=26.4.4
-export MAGISK_VER_CODE=26404
+export MAGISK_VER=27.0
+export MAGISK_VER_CODE=27000


### PR DESCRIPTION
Updated the Magisk version to 27.0 and the Magisk Version Code to 27000 (latest beta).
Latest canary/debug would be 27001.

Edit: Magisk stable got pushed to 27.0 too.