### PR TITLE
Revert "fix: add missing argument on kptools patch call"

### DIFF
--- a/app/src/main/assets/boot_patch.sh
+++ b/app/src/main/assets/boot_patch.sh
@@ -78,7 +78,7 @@ fi
 mv kernel kernel.ori
 
 echo "- Patching kernel"
-./kptools -p --image kernel.ori --skey "$SUPERKEY" --kpimg kpimg --out kernel
+./kptools -p kernel.ori --skey "$SUPERKEY" --kpimg kpimg --out kernel
 
 if [ $? -ne 0 ]; then
   echo "Patch error: $?"


### PR DESCRIPTION
This reverts commit 1ad25ae228a705d51e0f9c89d83fb6d676f70d70.