### PR TITLE
dependabot: Trigger on main branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: daily
       time: "21:00"
-    target-branch: master
+    target-branch: main
     registries:
       - maven-google
       - gradle-plugin


### PR DESCRIPTION
It's a mistake made by me. ;)
Our branch's name is 'main'.