### PR TITLE
manager: Introduce Hide APatch Manager feature

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,7 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
             excludes += "okhttp3/**"
             excludes += "kotlin/**"
+            excludes += "/org/bouncycastle/**"
             excludes += "org/**"
             excludes += "**.properties"
             excludes += "**.bin"
@@ -145,6 +146,7 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.devappx)
     implementation(libs.ini4j)
+    implementation(libs.bcpkix)
 
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.compose.ui.tooling)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="APatch"
         android:supportsRtl="true"
         android:theme="@style/Theme.APatch"
         tools:targetApi="33">

--- a/app/src/main/java/me/bmax/apatch/util/AXML.kt
+++ b/app/src/main/java/me/bmax/apatch/util/AXML.kt
@@ -1,0 +1,122 @@
+package me.bmax.apatch.util
+
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder.LITTLE_ENDIAN
+import java.nio.charset.Charset
+
+class AXML(b: ByteArray) {
+
+    var bytes = b
+        private set
+
+    companion object {
+        private const val CHUNK_SIZE_OFF = 4
+        private const val STRING_INDICES_OFF = 7 * 4
+        private val UTF_16LE = Charset.forName("UTF-16LE")
+    }
+
+    /**
+     * String pool header:
+     * 0:  0x1C0001
+     * 1:  chunk size
+     * 2:  number of strings
+     * 3:  number of styles (assert as 0)
+     * 4:  flags
+     * 5:  offset to string data
+     * 6:  offset to style data (assert as 0)
+     *
+     * Followed by an array of uint32_t with size = number of strings
+     * Each entry points to an offset into the string data
+     */
+    fun patchStrings(patchFn: (Array<String>) -> Unit): Boolean {
+        val buffer = ByteBuffer.wrap(bytes).order(LITTLE_ENDIAN)
+
+        fun findStringPool(): Int {
+            var offset = 8
+            while (offset < bytes.size) {
+                if (buffer.getInt(offset) == 0x1C0001)
+                    return offset
+                offset += buffer.getInt(offset + CHUNK_SIZE_OFF)
+            }
+            return -1
+        }
+
+        val start = findStringPool()
+        if (start < 0)
+            return false
+
+        // Read header
+        buffer.position(start + 4)
+        val intBuf = buffer.asIntBuffer()
+        val size = intBuf.get()
+        val count = intBuf.get()
+        intBuf.get()
+        intBuf.get()
+        val dataOff = start + intBuf.get()
+        intBuf.get()
+
+        val strList = ArrayList<String>(count)
+        // Collect all strings in the pool
+        for (i in 0 until count) {
+            val off = dataOff + intBuf.get()
+            val len = buffer.getShort(off)
+            strList.add(String(bytes, off + 2, len * 2, UTF_16LE))
+        }
+
+        val strArr = strList.toTypedArray()
+        patchFn(strArr)
+
+        // Write everything before string data, will patch values later
+        val baos = RawByteStream()
+        baos.write(bytes, 0, dataOff)
+
+        // Write string data
+        val offList = IntArray(count)
+        for (i in 0 until count) {
+            offList[i] = baos.size() - dataOff
+            val str = strArr[i]
+            baos.write(str.length.toShortBytes())
+            baos.write(str.toByteArray(UTF_16LE))
+            // Null terminate
+            baos.write(0)
+            baos.write(0)
+        }
+        baos.align()
+
+        val sizeDiff = baos.size() - start - size
+        val newBuffer = ByteBuffer.wrap(baos.buf).order(LITTLE_ENDIAN)
+
+        // Patch XML size
+        newBuffer.putInt(CHUNK_SIZE_OFF, buffer.getInt(CHUNK_SIZE_OFF) + sizeDiff)
+        // Patch string pool size
+        newBuffer.putInt(start + CHUNK_SIZE_OFF, size + sizeDiff)
+        // Patch index table
+        newBuffer.position(start + STRING_INDICES_OFF)
+        val newIntBuf = newBuffer.asIntBuffer()
+        offList.forEach { newIntBuf.put(it) }
+
+        // Write the rest of the chunks
+        val nextOff = start + size
+        baos.write(bytes, nextOff, bytes.size - nextOff)
+
+        bytes = baos.toByteArray()
+        return true
+    }
+
+    private fun Int.toShortBytes(): ByteArray {
+        val b = ByteBuffer.allocate(2).order(LITTLE_ENDIAN)
+        b.putShort(this.toShort())
+        return b.array()
+    }
+
+    private class RawByteStream : ByteArrayOutputStream() {
+        val buf: ByteArray get() = buf
+
+        fun align(alignment: Int = 4) {
+            val newCount = (count + alignment - 1) / alignment * alignment
+            for (i in 0 until (newCount - count))
+                write(0)
+        }
+    }
+}

--- a/app/src/main/java/me/bmax/apatch/util/HideAPK.kt
+++ b/app/src/main/java/me/bmax/apatch/util/HideAPK.kt
@@ -1,0 +1,128 @@
+package me.bmax.apatch.util
+
+import android.content.Context
+import android.widget.Toast
+import com.topjohnwu.superuser.Shell
+import dev.utils.app.AppUtils.getPackageManager
+import dev.utils.app.AppUtils.getPackageName
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.withContext
+import me.bmax.apatch.BuildConfig.APPLICATION_ID
+import me.bmax.apatch.R
+import me.bmax.apatch.util.apksign.JarMap
+import me.bmax.apatch.util.apksign.SignApk
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+import java.security.SecureRandom
+
+object HideAPK {
+    private const val ALPHA = "abcdefghijklmnopqrstuvwxyz"
+    private const val ALPHADOTS = "$ALPHA....."
+    private const val ANDROID_MANIFEST = "AndroidManifest.xml"
+
+    @JvmStatic
+    private fun genPackageName(): String {
+        val random = SecureRandom()
+        val len = 5 + random.nextInt(15)
+        val builder = StringBuilder(len)
+        var next: Char
+        var prev = 0.toChar()
+        for (i in 0 until len) {
+            next = if (prev == '.' || i == 0 || i == len - 1) {
+                ALPHA[random.nextInt(ALPHA.length)]
+            } else {
+                ALPHADOTS[random.nextInt(ALPHADOTS.length)]
+            }
+            builder.append(next)
+            prev = next
+        }
+        if (!builder.contains('.')) {
+            // Pick a random index and set it as dot
+            val idx = random.nextInt(len - 2)
+            builder[idx + 1] = '.'
+        }
+        return builder.toString()
+    }
+
+    @JvmStatic
+    private fun patch(
+        apk: File, out: OutputStream,
+        pkg: String, label: CharSequence
+    ): Boolean {
+        val origLabel = "APatch" // TODO: Get this in a better way instead of hardcode
+        try {
+            JarMap.open(apk, true).use { jar ->
+                val je = jar.getJarEntry(ANDROID_MANIFEST)
+                val xml = AXML(jar.getRawData(je))
+
+                if (!xml.patchStrings {
+                    for (i in it.indices) {
+                        val s = it[i]
+                        if (s.contains(APPLICATION_ID) && !s.contains("ui.MainActivity") && !s.contains(".APApplication")) {
+                            it[i] = s.replace(APPLICATION_ID, pkg)
+                        } else if (s == origLabel) {
+                            it[i] = label.toString()
+                        }
+                    }
+                }) {
+                    return false
+                }
+
+                // Write apk changes
+                jar.getOutputStream(je).use { it.write(xml.bytes) }
+                val keys = Keygen()
+                SignApk.sign(keys.cert, keys.key, jar, out)
+                return true
+            }
+        } catch (e: Exception) {
+            Timber.e(e)
+            return false
+        }
+    }
+
+    @JvmStatic
+    private fun patchAndHide(context: Context, label: String, shell: Shell): Boolean {
+        val apkPath: String = getPackageManager().getApplicationInfo(getPackageName(), 0).sourceDir
+        val source = File(apkPath)
+
+        // Generate a new random package name and signature
+        val repack = File(context.cacheDir, "patched.apk")
+        val pkg = genPackageName()
+
+        if (!patch(source, FileOutputStream(repack), pkg, label))
+            return false
+
+        // https://github.com/topjohnwu/Magisk/blob/master/app/src/main/res/raw/manager.sh#L135
+        val result = shellForResult(shell,
+            "adb_pm_install() { local tmp=/data/local/tmp/temp.apk; cp -f \"\$1\" \$tmp; chmod 644 \$tmp; su 2000 -c \"pm install -g \$tmp\" || pm install -g \$tmp || su 1000 -c \"pm install -g \$tmp\"; local res=\$?; rm -f \$tmp; if [ \$res = 0 ]; then appops set \"\$2\" REQUEST_INSTALL_PACKAGES allow; fi; return \$res; }\n",
+            "adb_pm_install $repack $pkg",
+            "am start -n $pkg/$APPLICATION_ID.ui.MainActivity",
+            "pm uninstall $APPLICATION_ID",
+        )
+
+        return result.isSuccess
+    }
+
+    @Suppress("DEPRECATION")
+    suspend fun hide(context: Context, label: String) {
+        val dialog = android.app.ProgressDialog(context).apply {
+            setTitle(context.getString(R.string.hide_apatch_manager))
+            isIndeterminate = true
+            setCancelable(false)
+            show()
+        }
+        val onFailure = Runnable {
+            dialog.dismiss()
+            Toast.makeText(context, context.getString(R.string.hide_apatch_manager_failure), Toast.LENGTH_LONG).show()
+        }
+        val shell = tryGetRootShell()
+        if (!shell.isRoot) {
+            onFailure.run()
+        }
+        val success = withContext(Dispatchers.IO) { patchAndHide(context, label, shell)}
+        if (!success) onFailure.run()
+    }
+}

--- a/app/src/main/java/me/bmax/apatch/util/Keygen.kt
+++ b/app/src/main/java/me/bmax/apatch/util/Keygen.kt
@@ -1,0 +1,67 @@
+package me.bmax.apatch.util
+
+import android.util.Base64
+import android.util.Base64OutputStream
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.cert.X509v3CertificateBuilder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import java.io.ByteArrayOutputStream
+import java.math.BigInteger
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import java.util.Calendar
+import java.util.Locale
+import java.util.Random
+import java.util.zip.GZIPOutputStream
+
+private interface CertKeyProvider {
+    val cert: X509Certificate
+    val key: PrivateKey
+}
+
+class Keygen : CertKeyProvider {
+
+    companion object {
+        private const val ALIAS = "apatch"
+        private val PASSWORD get() = "apatch".toCharArray()
+        private const val DNAME = "C=US,ST=California,L=Mountain View,O=Google Inc.,OU=Android,CN=Android"
+        private const val BASE64_FLAG = Base64.NO_PADDING or Base64.NO_WRAP
+
+    }
+
+    private val start = Calendar.getInstance().apply { add(Calendar.MONTH, -3) }
+    private val end = (start.clone() as Calendar).apply { add(Calendar.YEAR, 30) }
+
+    private val ks = init()
+    override val cert = ks.getCertificate(ALIAS) as X509Certificate
+    override val key = ks.getKey(ALIAS, PASSWORD) as PrivateKey
+
+    private fun init(): KeyStore {
+        val ks = KeyStore.getInstance("PKCS12")
+        ks.load(null)
+
+        // Generate new private key and certificate
+        val kp = KeyPairGenerator.getInstance("RSA").apply { initialize(4096) }.genKeyPair()
+        val dname = X500Name(DNAME)
+        val builder = X509v3CertificateBuilder(
+            dname, BigInteger(160, Random()),
+            start.time, end.time, Locale.ROOT, dname,
+            SubjectPublicKeyInfo.getInstance(kp.public.encoded)
+        )
+        val signer = JcaContentSignerBuilder("SHA1WithRSA").build(kp.private)
+        val cert = JcaX509CertificateConverter().getCertificate(builder.build(signer))
+
+        // Store them into keystore
+        ks.setKeyEntry(ALIAS, kp.private, PASSWORD, arrayOf(cert))
+        val bytes = ByteArrayOutputStream()
+        GZIPOutputStream(Base64OutputStream(bytes, BASE64_FLAG)).use {
+            ks.store(it, PASSWORD)
+        }
+
+        return ks
+    }
+}

--- a/app/src/main/java/me/bmax/apatch/util/apksign/ApkSignerV2.java
+++ b/app/src/main/java/me/bmax/apatch/util/apksign/ApkSignerV2.java
@@ -1,0 +1,772 @@
+package me.bmax.apatch.util.apksign;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.DigestException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * APK Signature Scheme v2 signer.
+ *
+ * <p>APK Signature Scheme v2 is a whole-file signature scheme which aims to protect every single
+ * bit of the APK, as opposed to the JAR Signature Scheme which protects only the names and
+ * uncompressed contents of ZIP entries.
+ */
+public abstract class ApkSignerV2 {
+    /*
+     * The two main goals of APK Signature Scheme v2 are:
+     * 1. Detect any unauthorized modifications to the APK. This is achieved by making the signature
+     *    cover every byte of the APK being signed.
+     * 2. Enable much faster signature and integrity verification. This is achieved by requiring
+     *    only a minimal amount of APK parsing before the signature is verified, thus completely
+     *    bypassing ZIP entry decompression and by making integrity verification parallelizable by
+     *    employing a hash tree.
+     *
+     * The generated signature block is wrapped into an APK Signing Block and inserted into the
+     * original APK immediately before the start of ZIP Central Directory. This is to ensure that
+     * JAR and ZIP parsers continue to work on the signed APK. The APK Signing Block is designed for
+     * extensibility. For example, a future signature scheme could insert its signatures there as
+     * well. The contract of the APK Signing Block is that all contents outside of the block must be
+     * protected by signatures inside the block.
+     */
+
+    public static final int SIGNATURE_RSA_PSS_WITH_SHA256 = 0x0101;
+    public static final int SIGNATURE_RSA_PSS_WITH_SHA512 = 0x0102;
+    public static final int SIGNATURE_RSA_PKCS1_V1_5_WITH_SHA256 = 0x0103;
+    public static final int SIGNATURE_RSA_PKCS1_V1_5_WITH_SHA512 = 0x0104;
+    public static final int SIGNATURE_ECDSA_WITH_SHA256 = 0x0201;
+    public static final int SIGNATURE_ECDSA_WITH_SHA512 = 0x0202;
+    public static final int SIGNATURE_DSA_WITH_SHA256 = 0x0301;
+    public static final int SIGNATURE_DSA_WITH_SHA512 = 0x0302;
+
+    /**
+     * {@code .SF} file header section attribute indicating that the APK is signed not just with
+     * JAR signature scheme but also with APK Signature Scheme v2 or newer. This attribute
+     * facilitates v2 signature stripping detection.
+     *
+     * <p>The attribute contains a comma-separated set of signature scheme IDs.
+     */
+    public static final String SF_ATTRIBUTE_ANDROID_APK_SIGNED_NAME = "X-Android-APK-Signed";
+    public static final String SF_ATTRIBUTE_ANDROID_APK_SIGNED_VALUE = "2";
+
+    private static final int CONTENT_DIGEST_CHUNKED_SHA256 = 0;
+    private static final int CONTENT_DIGEST_CHUNKED_SHA512 = 1;
+
+    private static final int CONTENT_DIGESTED_CHUNK_MAX_SIZE_BYTES = 1024 * 1024;
+
+    private static final byte[] APK_SIGNING_BLOCK_MAGIC =
+          new byte[] {
+              0x41, 0x50, 0x4b, 0x20, 0x53, 0x69, 0x67, 0x20,
+              0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x20, 0x34, 0x32,
+          };
+    private static final int APK_SIGNATURE_SCHEME_V2_BLOCK_ID = 0x7109871a;
+
+    private ApkSignerV2() {}
+
+    /**
+     * Signer configuration.
+     */
+    public static final class SignerConfig {
+        /** Private key. */
+        public PrivateKey privateKey;
+
+        /**
+         * Certificates, with the first certificate containing the public key corresponding to
+         * {@link #privateKey}.
+         */
+        public List<X509Certificate> certificates;
+
+        /**
+         * List of signature algorithms with which to sign (see {@code SIGNATURE_...} constants).
+         */
+        public List<Integer> signatureAlgorithms;
+    }
+
+    /**
+     * Signs the provided APK using APK Signature Scheme v2 and returns the signed APK as a list of
+     * consecutive chunks.
+     *
+     * <p>NOTE: To enable APK signature verifier to detect v2 signature stripping, header sections
+     * of META-INF/*.SF files of APK being signed must contain the
+     * {@code X-Android-APK-Signed: true} attribute.
+     *
+     * @param inputApk contents of the APK to be signed. The APK starts at the current position
+     *        of the buffer and ends at the limit of the buffer.
+     * @param signerConfigs signer configurations, one for each signer.
+     *
+     * @throws ApkParseException if the APK cannot be parsed.
+     * @throws InvalidKeyException if a signing key is not suitable for this signature scheme or
+     *         cannot be used in general.
+     * @throws SignatureException if an error occurs when computing digests of generating
+     *         signatures.
+     */
+    public static ByteBuffer[] sign(
+            ByteBuffer inputApk,
+            List<SignerConfig> signerConfigs)
+                    throws ApkParseException, InvalidKeyException, SignatureException {
+        // Slice/create a view in the inputApk to make sure that:
+        // 1. inputApk is what's between position and limit of the original inputApk, and
+        // 2. changes to position, limit, and byte order are not reflected in the original.
+        ByteBuffer originalInputApk = inputApk;
+        inputApk = originalInputApk.slice();
+        inputApk.order(ByteOrder.LITTLE_ENDIAN);
+
+        // Locate ZIP End of Central Directory (EoCD), Central Directory, and check that Central
+        // Directory is immediately followed by the ZIP End of Central Directory.
+        int eocdOffset = ZipUtils.findZipEndOfCentralDirectoryRecord(inputApk);
+        if (eocdOffset == -1) {
+            throw new ApkParseException("Failed to locate ZIP End of Central Directory");
+        }
+        if (ZipUtils.isZip64EndOfCentralDirectoryLocatorPresent(inputApk, eocdOffset)) {
+            throw new ApkParseException("ZIP64 format not supported");
+        }
+        inputApk.position(eocdOffset);
+        long centralDirSizeLong = ZipUtils.getZipEocdCentralDirectorySizeBytes(inputApk);
+        if (centralDirSizeLong > Integer.MAX_VALUE) {
+            throw new ApkParseException(
+                    "ZIP Central Directory size out of range: " + centralDirSizeLong);
+        }
+        int centralDirSize = (int) centralDirSizeLong;
+        long centralDirOffsetLong = ZipUtils.getZipEocdCentralDirectoryOffset(inputApk);
+        if (centralDirOffsetLong > Integer.MAX_VALUE) {
+            throw new ApkParseException(
+                    "ZIP Central Directory offset in file out of range: " + centralDirOffsetLong);
+        }
+        int centralDirOffset = (int) centralDirOffsetLong;
+        int expectedEocdOffset = centralDirOffset + centralDirSize;
+        if (expectedEocdOffset < centralDirOffset) {
+            throw new ApkParseException(
+                    "ZIP Central Directory extent too large. Offset: " + centralDirOffset
+                            + ", size: " + centralDirSize);
+        }
+        if (eocdOffset != expectedEocdOffset) {
+            throw new ApkParseException(
+                    "ZIP Central Directory not immeiately followed by ZIP End of"
+                            + " Central Directory. CD end: " + expectedEocdOffset
+                            + ", EoCD start: " + eocdOffset);
+        }
+
+        // Create ByteBuffers holding the contents of everything before ZIP Central Directory,
+        // ZIP Central Directory, and ZIP End of Central Directory.
+        inputApk.clear();
+        ByteBuffer beforeCentralDir = getByteBuffer(inputApk, centralDirOffset);
+        ByteBuffer centralDir = getByteBuffer(inputApk, eocdOffset - centralDirOffset);
+        // Create a copy of End of Central Directory because we'll need modify its contents later.
+        byte[] eocdBytes = new byte[inputApk.remaining()];
+        inputApk.get(eocdBytes);
+        ByteBuffer eocd = ByteBuffer.wrap(eocdBytes);
+        eocd.order(inputApk.order());
+
+        // Figure which which digests to use for APK contents.
+        Set<Integer> contentDigestAlgorithms = new HashSet<>();
+        for (SignerConfig signerConfig : signerConfigs) {
+            for (int signatureAlgorithm : signerConfig.signatureAlgorithms) {
+                contentDigestAlgorithms.add(
+                        getSignatureAlgorithmContentDigestAlgorithm(signatureAlgorithm));
+            }
+        }
+
+        // Compute digests of APK contents.
+        Map<Integer, byte[]> contentDigests; // digest algorithm ID -> digest
+        try {
+            contentDigests =
+                    computeContentDigests(
+                            contentDigestAlgorithms,
+                            new ByteBuffer[] {beforeCentralDir, centralDir, eocd});
+        } catch (DigestException e) {
+            throw new SignatureException("Failed to compute digests of APK", e);
+        }
+
+        // Sign the digests and wrap the signatures and signer info into an APK Signing Block.
+        ByteBuffer apkSigningBlock =
+                ByteBuffer.wrap(generateApkSigningBlock(signerConfigs, contentDigests));
+
+        // Update Central Directory Offset in End of Central Directory Record. Central Directory
+        // follows the APK Signing Block and thus is shifted by the size of the APK Signing Block.
+        centralDirOffset += apkSigningBlock.remaining();
+        eocd.clear();
+        ZipUtils.setZipEocdCentralDirectoryOffset(eocd, centralDirOffset);
+
+        // Follow the Java NIO pattern for ByteBuffer whose contents have been consumed.
+        originalInputApk.position(originalInputApk.limit());
+
+        // Reset positions (to 0) and limits (to capacity) in the ByteBuffers below to follow the
+        // Java NIO pattern for ByteBuffers which are ready for their contents to be read by caller.
+        // Contrary to the name, this does not clear the contents of these ByteBuffer.
+        beforeCentralDir.clear();
+        centralDir.clear();
+        eocd.clear();
+
+        // Insert APK Signing Block immediately before the ZIP Central Directory.
+        return new ByteBuffer[] {
+            beforeCentralDir,
+            apkSigningBlock,
+            centralDir,
+            eocd,
+        };
+    }
+
+    private static Map<Integer, byte[]> computeContentDigests(
+            Set<Integer> digestAlgorithms,
+            ByteBuffer[] contents) throws DigestException {
+        // For each digest algorithm the result is computed as follows:
+        // 1. Each segment of contents is split into consecutive chunks of 1 MB in size.
+        //    The final chunk will be shorter iff the length of segment is not a multiple of 1 MB.
+        //    No chunks are produced for empty (zero length) segments.
+        // 2. The digest of each chunk is computed over the concatenation of byte 0xa5, the chunk's
+        //    length in bytes (uint32 little-endian) and the chunk's contents.
+        // 3. The output digest is computed over the concatenation of the byte 0x5a, the number of
+        //    chunks (uint32 little-endian) and the concatenation of digests of chunks of all
+        //    segments in-order.
+
+        int chunkCount = 0;
+        for (ByteBuffer input : contents) {
+            chunkCount += getChunkCount(input.remaining(), CONTENT_DIGESTED_CHUNK_MAX_SIZE_BYTES);
+        }
+
+        final Map<Integer, byte[]> digestsOfChunks = new HashMap<>(digestAlgorithms.size());
+        for (int digestAlgorithm : digestAlgorithms) {
+            int digestOutputSizeBytes = getContentDigestAlgorithmOutputSizeBytes(digestAlgorithm);
+            byte[] concatenationOfChunkCountAndChunkDigests =
+                    new byte[5 + chunkCount * digestOutputSizeBytes];
+            concatenationOfChunkCountAndChunkDigests[0] = 0x5a;
+            setUnsignedInt32LittleEngian(
+                    chunkCount, concatenationOfChunkCountAndChunkDigests, 1);
+            digestsOfChunks.put(digestAlgorithm, concatenationOfChunkCountAndChunkDigests);
+        }
+
+        int chunkIndex = 0;
+        byte[] chunkContentPrefix = new byte[5];
+        chunkContentPrefix[0] = (byte) 0xa5;
+        // Optimization opportunity: digests of chunks can be computed in parallel.
+        for (ByteBuffer input : contents) {
+            while (input.hasRemaining()) {
+                int chunkSize =
+                        Math.min(input.remaining(), CONTENT_DIGESTED_CHUNK_MAX_SIZE_BYTES);
+                final ByteBuffer chunk = getByteBuffer(input, chunkSize);
+                for (int digestAlgorithm : digestAlgorithms) {
+                    String jcaAlgorithmName =
+                            getContentDigestAlgorithmJcaDigestAlgorithm(digestAlgorithm);
+                    MessageDigest md;
+                    try {
+                        md = MessageDigest.getInstance(jcaAlgorithmName);
+                    } catch (NoSuchAlgorithmException e) {
+                        throw new DigestException(
+                                jcaAlgorithmName + " MessageDigest not supported", e);
+                    }
+                    // Reset position to 0 and limit to capacity. Position would've been modified
+                    // by the preceding iteration of this loop. NOTE: Contrary to the method name,
+                    // this does not modify the contents of the chunk.
+                    chunk.clear();
+                    setUnsignedInt32LittleEngian(chunk.remaining(), chunkContentPrefix, 1);
+                    md.update(chunkContentPrefix);
+                    md.update(chunk);
+                    byte[] concatenationOfChunkCountAndChunkDigests =
+                            digestsOfChunks.get(digestAlgorithm);
+                    int expectedDigestSizeBytes =
+                            getContentDigestAlgorithmOutputSizeBytes(digestAlgorithm);
+                    int actualDigestSizeBytes =
+                            md.digest(
+                                    concatenationOfChunkCountAndChunkDigests,
+                                    5 + chunkIndex * expectedDigestSizeBytes,
+                                    expectedDigestSizeBytes);
+                    if (actualDigestSizeBytes != expectedDigestSizeBytes) {
+                        throw new DigestException(
+                                "Unexpected output size of " + md.getAlgorithm()
+                                        + " digest: " + actualDigestSizeBytes);
+                    }
+                }
+                chunkIndex++;
+            }
+        }
+
+        Map<Integer, byte[]> result = new HashMap<>(digestAlgorithms.size());
+        for (Map.Entry<Integer, byte[]> entry : digestsOfChunks.entrySet()) {
+            int digestAlgorithm = entry.getKey();
+            byte[] concatenationOfChunkCountAndChunkDigests = entry.getValue();
+            String jcaAlgorithmName = getContentDigestAlgorithmJcaDigestAlgorithm(digestAlgorithm);
+            MessageDigest md;
+            try {
+                md = MessageDigest.getInstance(jcaAlgorithmName);
+            } catch (NoSuchAlgorithmException e) {
+                throw new DigestException(jcaAlgorithmName + " MessageDigest not supported", e);
+            }
+            result.put(digestAlgorithm, md.digest(concatenationOfChunkCountAndChunkDigests));
+        }
+        return result;
+    }
+
+    private static int getChunkCount(int inputSize, int chunkSize) {
+        return (inputSize + chunkSize - 1) / chunkSize;
+    }
+
+    private static void setUnsignedInt32LittleEngian(int value, byte[] result, int offset) {
+        result[offset] = (byte) (value & 0xff);
+        result[offset + 1] = (byte) ((value >> 8) & 0xff);
+        result[offset + 2] = (byte) ((value >> 16) & 0xff);
+        result[offset + 3] = (byte) ((value >> 24) & 0xff);
+    }
+
+    private static byte[] generateApkSigningBlock(
+            List<SignerConfig> signerConfigs,
+            Map<Integer, byte[]> contentDigests) throws InvalidKeyException, SignatureException {
+        byte[] apkSignatureSchemeV2Block =
+                generateApkSignatureSchemeV2Block(signerConfigs, contentDigests);
+        return generateApkSigningBlock(apkSignatureSchemeV2Block);
+    }
+
+    private static byte[] generateApkSigningBlock(byte[] apkSignatureSchemeV2Block) {
+        // FORMAT:
+        // uint64:  size (excluding this field)
+        // repeated ID-value pairs:
+        //     uint64:           size (excluding this field)
+        //     uint32:           ID
+        //     (size - 4) bytes: value
+        // uint64:  size (same as the one above)
+        // uint128: magic
+
+        int resultSize =
+                8 // size
+                + 8 + 4 + apkSignatureSchemeV2Block.length // v2Block as ID-value pair
+                + 8 // size
+                + 16 // magic
+                ;
+        ByteBuffer result = ByteBuffer.allocate(resultSize);
+        result.order(ByteOrder.LITTLE_ENDIAN);
+        long blockSizeFieldValue = resultSize - 8;
+        result.putLong(blockSizeFieldValue);
+
+        long pairSizeFieldValue = 4 + apkSignatureSchemeV2Block.length;
+        result.putLong(pairSizeFieldValue);
+        result.putInt(APK_SIGNATURE_SCHEME_V2_BLOCK_ID);
+        result.put(apkSignatureSchemeV2Block);
+
+        result.putLong(blockSizeFieldValue);
+        result.put(APK_SIGNING_BLOCK_MAGIC);
+
+        return result.array();
+    }
+
+    private static byte[] generateApkSignatureSchemeV2Block(
+            List<SignerConfig> signerConfigs,
+            Map<Integer, byte[]> contentDigests) throws InvalidKeyException, SignatureException {
+        // FORMAT:
+        // * length-prefixed sequence of length-prefixed signer blocks.
+
+        List<byte[]> signerBlocks = new ArrayList<>(signerConfigs.size());
+        int signerNumber = 0;
+        for (SignerConfig signerConfig : signerConfigs) {
+            signerNumber++;
+            byte[] signerBlock;
+            try {
+                signerBlock = generateSignerBlock(signerConfig, contentDigests);
+            } catch (InvalidKeyException e) {
+                throw new InvalidKeyException("Signer #" + signerNumber + " failed", e);
+            } catch (SignatureException e) {
+                throw new SignatureException("Signer #" + signerNumber + " failed", e);
+            }
+            signerBlocks.add(signerBlock);
+        }
+
+        return encodeAsSequenceOfLengthPrefixedElements(
+                new byte[][] {
+                    encodeAsSequenceOfLengthPrefixedElements(signerBlocks),
+                });
+    }
+
+    private static byte[] generateSignerBlock(
+            SignerConfig signerConfig,
+            Map<Integer, byte[]> contentDigests) throws InvalidKeyException, SignatureException {
+        if (signerConfig.certificates.isEmpty()) {
+            throw new SignatureException("No certificates configured for signer");
+        }
+        PublicKey publicKey = signerConfig.certificates.get(0).getPublicKey();
+
+        byte[] encodedPublicKey = encodePublicKey(publicKey);
+
+        V2SignatureSchemeBlock.SignedData signedData = new V2SignatureSchemeBlock.SignedData();
+        try {
+            signedData.certificates = encodeCertificates(signerConfig.certificates);
+        } catch (CertificateEncodingException e) {
+            throw new SignatureException("Failed to encode certificates", e);
+        }
+
+        List<Pair<Integer, byte[]>> digests =
+                new ArrayList<>(signerConfig.signatureAlgorithms.size());
+        for (int signatureAlgorithm : signerConfig.signatureAlgorithms) {
+            int contentDigestAlgorithm =
+                    getSignatureAlgorithmContentDigestAlgorithm(signatureAlgorithm);
+            byte[] contentDigest = contentDigests.get(contentDigestAlgorithm);
+            if (contentDigest == null) {
+                throw new RuntimeException(
+                        getContentDigestAlgorithmJcaDigestAlgorithm(contentDigestAlgorithm)
+                        + " content digest for "
+                        + getSignatureAlgorithmJcaSignatureAlgorithm(signatureAlgorithm)
+                        + " not computed");
+            }
+            digests.add(Pair.create(signatureAlgorithm, contentDigest));
+        }
+        signedData.digests = digests;
+
+        V2SignatureSchemeBlock.Signer signer = new V2SignatureSchemeBlock.Signer();
+        // FORMAT:
+        // * length-prefixed sequence of length-prefixed digests:
+        //   * uint32: signature algorithm ID
+        //   * length-prefixed bytes: digest of contents
+        // * length-prefixed sequence of certificates:
+        //   * length-prefixed bytes: X.509 certificate (ASN.1 DER encoded).
+        // * length-prefixed sequence of length-prefixed additional attributes:
+        //   * uint32: ID
+        //   * (length - 4) bytes: value
+        signer.signedData = encodeAsSequenceOfLengthPrefixedElements(new byte[][] {
+            encodeAsSequenceOfLengthPrefixedPairsOfIntAndLengthPrefixedBytes(signedData.digests),
+            encodeAsSequenceOfLengthPrefixedElements(signedData.certificates),
+            // additional attributes
+            new byte[0],
+        });
+        signer.publicKey = encodedPublicKey;
+        signer.signatures = new ArrayList<>();
+        for (int signatureAlgorithm : signerConfig.signatureAlgorithms) {
+            Pair<String, ? extends AlgorithmParameterSpec> signatureParams =
+                    getSignatureAlgorithmJcaSignatureAlgorithm(signatureAlgorithm);
+            String jcaSignatureAlgorithm = signatureParams.getFirst();
+            AlgorithmParameterSpec jcaSignatureAlgorithmParams = signatureParams.getSecond();
+            byte[] signatureBytes;
+            try {
+                Signature signature = Signature.getInstance(jcaSignatureAlgorithm);
+                signature.initSign(signerConfig.privateKey);
+                if (jcaSignatureAlgorithmParams != null) {
+                    signature.setParameter(jcaSignatureAlgorithmParams);
+                }
+                signature.update(signer.signedData);
+                signatureBytes = signature.sign();
+            } catch (InvalidKeyException e) {
+                throw new InvalidKeyException("Failed sign using " + jcaSignatureAlgorithm, e);
+            } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException
+                    | SignatureException e) {
+                throw new SignatureException("Failed sign using " + jcaSignatureAlgorithm, e);
+            }
+
+            try {
+                Signature signature = Signature.getInstance(jcaSignatureAlgorithm);
+                signature.initVerify(publicKey);
+                if (jcaSignatureAlgorithmParams != null) {
+                    signature.setParameter(jcaSignatureAlgorithmParams);
+                }
+                signature.update(signer.signedData);
+                if (!signature.verify(signatureBytes)) {
+                    throw new SignatureException("Signature did not verify");
+                }
+            } catch (InvalidKeyException e) {
+                throw new InvalidKeyException("Failed to verify generated " + jcaSignatureAlgorithm
+                        + " signature using public key from certificate", e);
+            } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException
+                    | SignatureException e) {
+                throw new SignatureException("Failed to verify generated " + jcaSignatureAlgorithm
+                        + " signature using public key from certificate", e);
+            }
+
+            signer.signatures.add(Pair.create(signatureAlgorithm, signatureBytes));
+        }
+
+        // FORMAT:
+        // * length-prefixed signed data
+        // * length-prefixed sequence of length-prefixed signatures:
+        //   * uint32: signature algorithm ID
+        //   * length-prefixed bytes: signature of signed data
+        // * length-prefixed bytes: public key (X.509 SubjectPublicKeyInfo, ASN.1 DER encoded)
+        return encodeAsSequenceOfLengthPrefixedElements(
+                new byte[][] {
+                    signer.signedData,
+                    encodeAsSequenceOfLengthPrefixedPairsOfIntAndLengthPrefixedBytes(
+                            signer.signatures),
+                    signer.publicKey,
+                });
+    }
+
+    private static final class V2SignatureSchemeBlock {
+        private static final class Signer {
+            public byte[] signedData;
+            public List<Pair<Integer, byte[]>> signatures;
+            public byte[] publicKey;
+        }
+
+        private static final class SignedData {
+            public List<Pair<Integer, byte[]>> digests;
+            public List<byte[]> certificates;
+        }
+    }
+
+    private static byte[] encodePublicKey(PublicKey publicKey) throws InvalidKeyException {
+        byte[] encodedPublicKey = null;
+        if ("X.509".equals(publicKey.getFormat())) {
+            encodedPublicKey = publicKey.getEncoded();
+        }
+        if (encodedPublicKey == null) {
+            try {
+                encodedPublicKey =
+                        KeyFactory.getInstance(publicKey.getAlgorithm())
+                                .getKeySpec(publicKey, X509EncodedKeySpec.class)
+                                .getEncoded();
+            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+                throw new InvalidKeyException(
+                        "Failed to obtain X.509 encoded form of public key " + publicKey
+                                + " of class " + publicKey.getClass().getName(),
+                        e);
+            }
+        }
+        if ((encodedPublicKey == null) || (encodedPublicKey.length == 0)) {
+            throw new InvalidKeyException(
+                    "Failed to obtain X.509 encoded form of public key " + publicKey
+                            + " of class " + publicKey.getClass().getName());
+        }
+        return encodedPublicKey;
+    }
+
+    public static List<byte[]> encodeCertificates(List<X509Certificate> certificates)
+            throws CertificateEncodingException {
+        List<byte[]> result = new ArrayList<>();
+        for (X509Certificate certificate : certificates) {
+            result.add(certificate.getEncoded());
+        }
+        return result;
+    }
+
+    private static byte[] encodeAsSequenceOfLengthPrefixedElements(List<byte[]> sequence) {
+        return encodeAsSequenceOfLengthPrefixedElements(
+                sequence.toArray(new byte[sequence.size()][]));
+    }
+
+    private static byte[] encodeAsSequenceOfLengthPrefixedElements(byte[][] sequence) {
+        int payloadSize = 0;
+        for (byte[] element : sequence) {
+            payloadSize += 4 + element.length;
+        }
+        ByteBuffer result = ByteBuffer.allocate(payloadSize);
+        result.order(ByteOrder.LITTLE_ENDIAN);
+        for (byte[] element : sequence) {
+            result.putInt(element.length);
+            result.put(element);
+        }
+        return result.array();
+      }
+
+    private static byte[] encodeAsSequenceOfLengthPrefixedPairsOfIntAndLengthPrefixedBytes(
+            List<Pair<Integer, byte[]>> sequence) {
+        int resultSize = 0;
+        for (Pair<Integer, byte[]> element : sequence) {
+            resultSize += 12 + element.getSecond().length;
+        }
+        ByteBuffer result = ByteBuffer.allocate(resultSize);
+        result.order(ByteOrder.LITTLE_ENDIAN);
+        for (Pair<Integer, byte[]> element : sequence) {
+            byte[] second = element.getSecond();
+            result.putInt(8 + second.length);
+            result.putInt(element.getFirst());
+            result.putInt(second.length);
+            result.put(second);
+        }
+        return result.array();
+    }
+
+    /**
+     * Relative <em>get</em> method for reading {@code size} number of bytes from the current
+     * position of this buffer.
+     *
+     * <p>This method reads the next {@code size} bytes at this buffer's current position,
+     * returning them as a {@code ByteBuffer} with start set to 0, limit and capacity set to
+     * {@code size}, byte order set to this buffer's byte order; and then increments the position by
+     * {@code size}.
+     */
+    private static ByteBuffer getByteBuffer(ByteBuffer source, int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("size: " + size);
+        }
+        int originalLimit = source.limit();
+        int position = source.position();
+        int limit = position + size;
+        if ((limit < position) || (limit > originalLimit)) {
+            throw new BufferUnderflowException();
+        }
+        source.limit(limit);
+        try {
+            ByteBuffer result = source.slice();
+            result.order(source.order());
+            source.position(limit);
+            return result;
+        } finally {
+            source.limit(originalLimit);
+        }
+    }
+
+    private static Pair<String, ? extends AlgorithmParameterSpec>
+            getSignatureAlgorithmJcaSignatureAlgorithm(int sigAlgorithm) {
+        switch (sigAlgorithm) {
+            case SIGNATURE_RSA_PSS_WITH_SHA256:
+                return Pair.create(
+                        "SHA256withRSA/PSS",
+                        new PSSParameterSpec(
+                                "SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 256 / 8, 1));
+            case SIGNATURE_RSA_PSS_WITH_SHA512:
+                return Pair.create(
+                        "SHA512withRSA/PSS",
+                        new PSSParameterSpec(
+                                "SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 512 / 8, 1));
+            case SIGNATURE_RSA_PKCS1_V1_5_WITH_SHA256:
+                return Pair.create("SHA256withRSA", null);
+            case SIGNATURE_RSA_PKCS1_V1_5_WITH_SHA512:
+                return Pair.create("SHA512withRSA", null);
+            case SIGNATURE_ECDSA_WITH_SHA256:
+                return Pair.create("SHA256withECDSA", null);
+            case SIGNATURE_ECDSA_WITH_SHA512:
+                return Pair.create("SHA512withECDSA", null);
+            case SIGNATURE_DSA_WITH_SHA256:
+                return Pair.create("SHA256withDSA", null);
+            case SIGNATURE_DSA_WITH_SHA512:
+                return Pair.create("SHA512withDSA", null);
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown signature algorithm: 0x"
+                                + Long.toHexString(sigAlgorithm & 0xffffffff));
+        }
+    }
+
+    private static int getSignatureAlgorithmContentDigestAlgorithm(int sigAlgorithm) {
+        switch (sigAlgorithm) {
+            case SIGNATURE_RSA_PSS_WITH_SHA256:
+            case SIGNATURE_RSA_PKCS1_V1_5_WITH_SHA256:
+            case SIGNATURE_ECDSA_WITH_SHA256:
+            case SIGNATURE_DSA_WITH_SHA256:
+                return CONTENT_DIGEST_CHUNKED_SHA256;
+            case SIGNATURE_RSA_PSS_WITH_SHA512:
+            case SIGNATURE_RSA_PKCS1_V1_5_WITH_SHA512:
+            case SIGNATURE_ECDSA_WITH_SHA512:
+            case SIGNATURE_DSA_WITH_SHA512:
+                return CONTENT_DIGEST_CHUNKED_SHA512;
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown signature algorithm: 0x"
+                                + Long.toHexString(sigAlgorithm & 0xffffffff));
+        }
+    }
+
+    private static String getContentDigestAlgorithmJcaDigestAlgorithm(int digestAlgorithm) {
+        switch (digestAlgorithm) {
+            case CONTENT_DIGEST_CHUNKED_SHA256:
+                return "SHA-256";
+            case CONTENT_DIGEST_CHUNKED_SHA512:
+                return "SHA-512";
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown content digest algorithm: " + digestAlgorithm);
+        }
+    }
+
+    private static int getContentDigestAlgorithmOutputSizeBytes(int digestAlgorithm) {
+        switch (digestAlgorithm) {
+            case CONTENT_DIGEST_CHUNKED_SHA256:
+                return 256 / 8;
+            case CONTENT_DIGEST_CHUNKED_SHA512:
+                return 512 / 8;
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown content digest algorithm: " + digestAlgorithm);
+        }
+    }
+
+    /**
+     * Indicates that APK file could not be parsed.
+     */
+    public static class ApkParseException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public ApkParseException(String message) {
+            super(message);
+        }
+
+        public ApkParseException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /**
+     * Pair of two elements.
+     */
+    private static class Pair<A, B> {
+        private final A mFirst;
+        private final B mSecond;
+
+        private Pair(A first, B second) {
+            mFirst = first;
+            mSecond = second;
+        }
+
+        public static <A, B> Pair<A, B> create(A first, B second) {
+            return new Pair<>(first, second);
+        }
+
+        public A getFirst() {
+            return mFirst;
+        }
+
+        public B getSecond() {
+            return mSecond;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((mFirst == null) ? 0 : mFirst.hashCode());
+            result = prime * result + ((mSecond == null) ? 0 : mSecond.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            @SuppressWarnings("rawtypes")
+            Pair other = (Pair) obj;
+            if (mFirst == null) {
+                if (other.mFirst != null) {
+                    return false;
+                }
+            } else if (!mFirst.equals(other.mFirst)) {
+                return false;
+            }
+            if (mSecond == null) {
+                return other.mSecond == null;
+            } else return mSecond.equals(other.mSecond);
+        }
+    }
+}

--- a/app/src/main/java/me/bmax/apatch/util/apksign/ByteArrayStream.java
+++ b/app/src/main/java/me/bmax/apatch/util/apksign/ByteArrayStream.java
@@ -1,0 +1,30 @@
+package me.bmax.apatch.util.apksign;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ByteArrayStream extends ByteArrayOutputStream {
+
+    public synchronized void readFrom(InputStream is) {
+        readFrom(is, Integer.MAX_VALUE);
+    }
+
+    public synchronized void readFrom(InputStream is, int len) {
+        int read;
+        byte buffer[] = new byte[4096];
+        try {
+            while ((read = is.read(buffer, 0, Math.min(len, buffer.length))) > 0) {
+                write(buffer, 0, read);
+                len -= read;
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public ByteArrayInputStream getInputStream() {
+        return new ByteArrayInputStream(buf, 0, count);
+    }
+}

--- a/app/src/main/java/me/bmax/apatch/util/apksign/JarMap.java
+++ b/app/src/main/java/me/bmax/apatch/util/apksign/JarMap.java
@@ -1,0 +1,166 @@
+package me.bmax.apatch.util.apksign;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public abstract class JarMap implements Closeable {
+
+    LinkedHashMap<String, JarEntry> entryMap;
+
+    public static JarMap open(File file, boolean verify) throws IOException {
+        return new FileMap(file, verify, ZipFile.OPEN_READ);
+    }
+
+    public static JarMap open(InputStream is, boolean verify) throws IOException {
+        return new StreamMap(is, verify);
+    }
+
+    public File getFile() {
+        return null;
+    }
+
+    public abstract Manifest getManifest() throws IOException;
+
+    public InputStream getInputStream(ZipEntry ze) throws IOException {
+        JarMapEntry e = getMapEntry(ze.getName());
+        return e != null ? e.data.getInputStream() : null;
+    }
+
+    public OutputStream getOutputStream(ZipEntry ze) {
+        if (entryMap == null)
+            entryMap = new LinkedHashMap<>();
+        JarMapEntry e = new JarMapEntry(ze.getName());
+        entryMap.put(ze.getName(), e);
+        return e.data;
+    }
+
+    public byte[] getRawData(ZipEntry ze) throws IOException {
+        JarMapEntry e = getMapEntry(ze.getName());
+        return e != null ? e.data.toByteArray() : null;
+    }
+
+    public abstract Enumeration<JarEntry> entries();
+
+    public final ZipEntry getEntry(String name) {
+        return getJarEntry(name);
+    }
+
+    public JarEntry getJarEntry(String name) {
+        return getMapEntry(name);
+    }
+
+    JarMapEntry getMapEntry(String name) {
+        JarMapEntry e = null;
+        if (entryMap != null)
+            e = (JarMapEntry) entryMap.get(name);
+        return e;
+    }
+
+    private static class FileMap extends JarMap {
+
+        private JarFile jarFile;
+
+        FileMap(File file, boolean verify, int mode) throws IOException {
+            jarFile = new JarFile(file, verify, mode);
+        }
+
+        @Override
+        public File getFile() {
+            return new File(jarFile.getName());
+        }
+
+        @Override
+        public Manifest getManifest() throws IOException {
+            return jarFile.getManifest();
+        }
+
+        @Override
+        public InputStream getInputStream(ZipEntry ze) throws IOException {
+            InputStream is = super.getInputStream(ze);
+            return is != null ? is : jarFile.getInputStream(ze);
+        }
+
+        @Override
+        public byte[] getRawData(ZipEntry ze) throws IOException {
+            byte[] b = super.getRawData(ze);
+            if (b != null)
+                return b;
+            ByteArrayStream bytes = new ByteArrayStream();
+            bytes.readFrom(jarFile.getInputStream(ze));
+            return bytes.toByteArray();
+        }
+
+        @Override
+        public Enumeration<JarEntry> entries() {
+            return jarFile.entries();
+        }
+
+        @Override
+        public JarEntry getJarEntry(String name) {
+            JarEntry e = getMapEntry(name);
+            return e != null ? e : jarFile.getJarEntry(name);
+        }
+
+        @Override
+        public void close() throws IOException {
+            jarFile.close();
+        }
+    }
+
+    private static class StreamMap extends JarMap {
+
+        private JarInputStream jis;
+
+        StreamMap(InputStream is, boolean verify) throws IOException {
+            jis = new JarInputStream(is, verify);
+            entryMap = new LinkedHashMap<>();
+            JarEntry entry;
+            while ((entry = jis.getNextJarEntry()) != null) {
+                entryMap.put(entry.getName(), new JarMapEntry(entry, jis));
+            }
+        }
+
+        @Override
+        public Manifest getManifest() {
+            return jis.getManifest();
+        }
+
+        @Override
+        public Enumeration<JarEntry> entries() {
+            return Collections.enumeration(entryMap.values());
+        }
+
+        @Override
+        public void close() throws IOException {
+            jis.close();
+        }
+    }
+
+    private static class JarMapEntry extends JarEntry {
+
+        ByteArrayStream data;
+
+        JarMapEntry(JarEntry je, InputStream is) {
+            super(je);
+            data = new ByteArrayStream();
+            data.readFrom(is);
+        }
+
+        JarMapEntry(String s) {
+            super(s);
+            data = new ByteArrayStream();
+        }
+    }
+}

--- a/app/src/main/java/me/bmax/apatch/util/apksign/SignApk.java
+++ b/app/src/main/java/me/bmax/apatch/util/apksign/SignApk.java
@@ -1,0 +1,567 @@
+package me.bmax.apatch.util.apksign;
+
+import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1OutputStream;
+import org.bouncycastle.cert.jcajce.JcaCertStore;
+import org.bouncycastle.cms.CMSException;
+import org.bouncycastle.cms.CMSProcessableByteArray;
+import org.bouncycastle.cms.CMSSignedData;
+import org.bouncycastle.cms.CMSSignedDataGenerator;
+import org.bouncycastle.cms.CMSTypedData;
+import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+import org.bouncycastle.util.encoders.Base64;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.security.DigestOutputStream;
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.TreeMap;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.regex.Pattern;
+
+/*
+ * Modified from from AOSP
+ * https://android.googlesource.com/platform/build/+/refs/tags/android-7.1.2_r39/tools/signapk/src/com/android/signapk/SignApk.java
+ * */
+
+public class SignApk {
+    private static final String CERT_SF_NAME = "META-INF/CERT.SF";
+    private static final String CERT_SIG_NAME = "META-INF/CERT.%s";
+    private static final String CERT_SF_MULTI_NAME = "META-INF/CERT%d.SF";
+    private static final String CERT_SIG_MULTI_NAME = "META-INF/CERT%d.%s";
+
+    // bitmasks for which hash algorithms we need the manifest to include.
+    private static final int USE_SHA1 = 1;
+    private static final int USE_SHA256 = 2;
+
+    /**
+     * Digest algorithm used when signing the APK using APK Signature Scheme v2.
+     */
+    private static final String APK_SIG_SCHEME_V2_DIGEST_ALGORITHM = "SHA-256";
+    // Files matching this pattern are not copied to the output.
+    private static final Pattern stripPattern =
+            Pattern.compile("^(META-INF/((.*)[.](SF|RSA|DSA|EC)|com/android/otacert))|(" +
+                    Pattern.quote(JarFile.MANIFEST_NAME) + ")$");
+
+    /**
+     * Return one of USE_SHA1 or USE_SHA256 according to the signature
+     * algorithm specified in the cert.
+     */
+    private static int getDigestAlgorithm(X509Certificate cert) {
+        String sigAlg = cert.getSigAlgName().toUpperCase(Locale.US);
+        if ("SHA1WITHRSA".equals(sigAlg) || "MD5WITHRSA".equals(sigAlg)) {
+            return USE_SHA1;
+        } else if (sigAlg.startsWith("SHA256WITH")) {
+            return USE_SHA256;
+        } else {
+            throw new IllegalArgumentException("unsupported signature algorithm \"" + sigAlg +
+                    "\" in cert [" + cert.getSubjectDN());
+        }
+    }
+
+    /**
+     * Returns the expected signature algorithm for this key type.
+     */
+    private static String getSignatureAlgorithm(X509Certificate cert) {
+        String keyType = cert.getPublicKey().getAlgorithm().toUpperCase(Locale.US);
+        if ("RSA".equalsIgnoreCase(keyType)) {
+            if (getDigestAlgorithm(cert) == USE_SHA256) {
+                return "SHA256withRSA";
+            } else {
+                return "SHA1withRSA";
+            }
+        } else if ("EC".equalsIgnoreCase(keyType)) {
+            return "SHA256withECDSA";
+        } else {
+            throw new IllegalArgumentException("unsupported key type: " + keyType);
+        }
+    }
+
+    /**
+     * Add the hash(es) of every file to the manifest, creating it if
+     * necessary.
+     */
+    private static Manifest addDigestsToManifest(JarMap jar, int hashes)
+            throws IOException, GeneralSecurityException {
+        Manifest input = jar.getManifest();
+        Manifest output = new Manifest();
+        Attributes main = output.getMainAttributes();
+        if (input != null) {
+            main.putAll(input.getMainAttributes());
+        } else {
+            main.putValue("Manifest-Version", "1.0");
+            main.putValue("Created-By", "1.0 (Android SignApk)");
+        }
+
+        MessageDigest md_sha1 = null;
+        MessageDigest md_sha256 = null;
+        if ((hashes & USE_SHA1) != 0) {
+            md_sha1 = MessageDigest.getInstance("SHA1");
+        }
+        if ((hashes & USE_SHA256) != 0) {
+            md_sha256 = MessageDigest.getInstance("SHA256");
+        }
+
+        byte[] buffer = new byte[4096];
+        int num;
+
+        // We sort the input entries by name, and add them to the
+        // output manifest in sorted order.  We expect that the output
+        // map will be deterministic.
+
+        TreeMap<String, JarEntry> byName = new TreeMap<>();
+
+        for (Enumeration<JarEntry> e = jar.entries(); e.hasMoreElements(); ) {
+            JarEntry entry = e.nextElement();
+            byName.put(entry.getName(), entry);
+        }
+
+        for (JarEntry entry : byName.values()) {
+            String name = entry.getName();
+            if (!entry.isDirectory() && !stripPattern.matcher(name).matches()) {
+                InputStream data = jar.getInputStream(entry);
+                while ((num = data.read(buffer)) > 0) {
+                    if (md_sha1 != null) md_sha1.update(buffer, 0, num);
+                    if (md_sha256 != null) md_sha256.update(buffer, 0, num);
+                }
+
+                Attributes attr = null;
+                if (input != null) attr = input.getAttributes(name);
+                attr = attr != null ? new Attributes(attr) : new Attributes();
+                // Remove any previously computed digests from this entry's attributes.
+                for (Iterator<Object> i = attr.keySet().iterator(); i.hasNext(); ) {
+                    Object key = i.next();
+                    if (!(key instanceof Attributes.Name)) {
+                        continue;
+                    }
+                    String attributeNameLowerCase =
+                            key.toString().toLowerCase(Locale.US);
+                    if (attributeNameLowerCase.endsWith("-digest")) {
+                        i.remove();
+                    }
+                }
+                // Add SHA-1 digest if requested
+                if (md_sha1 != null) {
+                    attr.putValue("SHA1-Digest",
+                            new String(Base64.encode(md_sha1.digest()), "ASCII"));
+                }
+                // Add SHA-256 digest if requested
+                if (md_sha256 != null) {
+                    attr.putValue("SHA-256-Digest",
+                            new String(Base64.encode(md_sha256.digest()), "ASCII"));
+                }
+                output.getEntries().put(name, attr);
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * Write a .SF file with a digest of the specified manifest.
+     */
+    private static void writeSignatureFile(Manifest manifest, OutputStream out,
+                                           int hash)
+            throws IOException, GeneralSecurityException {
+        Manifest sf = new Manifest();
+        Attributes main = sf.getMainAttributes();
+        main.putValue("Signature-Version", "1.0");
+        main.putValue("Created-By", "1.0 (Android SignApk)");
+        // Add APK Signature Scheme v2 signature stripping protection.
+        // This attribute indicates that this APK is supposed to have been signed using one or
+        // more APK-specific signature schemes in addition to the standard JAR signature scheme
+        // used by this code. APK signature verifier should reject the APK if it does not
+        // contain a signature for the signature scheme the verifier prefers out of this set.
+        main.putValue(
+                ApkSignerV2.SF_ATTRIBUTE_ANDROID_APK_SIGNED_NAME,
+                ApkSignerV2.SF_ATTRIBUTE_ANDROID_APK_SIGNED_VALUE);
+
+        MessageDigest md = MessageDigest.getInstance(hash == USE_SHA256 ? "SHA256" : "SHA1");
+        PrintStream print = new PrintStream(new DigestOutputStream(new ByteArrayOutputStream(), md),
+                true, "UTF-8");
+
+        // Digest of the entire manifest
+        manifest.write(print);
+        print.flush();
+        main.putValue(hash == USE_SHA256 ? "SHA-256-Digest-Manifest" : "SHA1-Digest-Manifest",
+                new String(Base64.encode(md.digest()), "ASCII"));
+
+        Map<String, Attributes> entries = manifest.getEntries();
+        for (Map.Entry<String, Attributes> entry : entries.entrySet()) {
+            // Digest of the manifest stanza for this entry.
+            print.print("Name: " + entry.getKey() + "\r\n");
+            for (Map.Entry<Object, Object> att : entry.getValue().entrySet()) {
+                print.print(att.getKey() + ": " + att.getValue() + "\r\n");
+            }
+            print.print("\r\n");
+            print.flush();
+
+            Attributes sfAttr = new Attributes();
+            sfAttr.putValue(hash == USE_SHA256 ? "SHA-256-Digest" : "SHA1-Digest",
+                    new String(Base64.encode(md.digest()), "ASCII"));
+            sf.getEntries().put(entry.getKey(), sfAttr);
+        }
+
+        CountOutputStream cout = new CountOutputStream(out);
+        sf.write(cout);
+
+        // A bug in the java.util.jar implementation of Android platforms
+        // up to version 1.6 will cause a spurious IOException to be thrown
+        // if the length of the signature file is a multiple of 1024 bytes.
+        // As a workaround, add an extra CRLF in this case.
+        if ((cout.size() % 1024) == 0) {
+            cout.write('\r');
+            cout.write('\n');
+        }
+    }
+
+    /**
+     * Sign data and write the digital signature to 'out'.
+     */
+    private static void writeSignatureBlock(
+            CMSTypedData data, X509Certificate publicKey, PrivateKey privateKey, OutputStream out)
+            throws IOException,
+            CertificateEncodingException,
+            OperatorCreationException,
+            CMSException {
+        ArrayList<X509Certificate> certList = new ArrayList<>(1);
+        certList.add(publicKey);
+        JcaCertStore certs = new JcaCertStore(certList);
+
+        CMSSignedDataGenerator gen = new CMSSignedDataGenerator();
+        ContentSigner signer = new JcaContentSignerBuilder(getSignatureAlgorithm(publicKey))
+                .build(privateKey);
+        gen.addSignerInfoGenerator(
+                new JcaSignerInfoGeneratorBuilder(new JcaDigestCalculatorProviderBuilder().build())
+                        .setDirectSignature(true)
+                        .build(signer, publicKey)
+        );
+        gen.addCertificates(certs);
+        CMSSignedData sigData = gen.generate(data, false);
+
+        try (ASN1InputStream asn1 = new ASN1InputStream(sigData.getEncoded())) {
+            ASN1OutputStream dos = ASN1OutputStream.create(out, ASN1Encoding.DER);
+            dos.writeObject(asn1.readObject());
+        }
+    }
+
+    /**
+     * Copy all the files in a manifest from input to output.  We set
+     * the modification times in the output to a fixed time, so as to
+     * reduce variation in the output file and make incremental OTAs
+     * more efficient.
+     */
+    private static void copyFiles(Manifest manifest, JarMap in, JarOutputStream out,
+                                  long timestamp, int defaultAlignment) throws IOException {
+        byte[] buffer = new byte[4096];
+        int num;
+
+        Map<String, Attributes> entries = manifest.getEntries();
+        ArrayList<String> names = new ArrayList<>(entries.keySet());
+        Collections.sort(names);
+
+        boolean firstEntry = true;
+        long offset = 0L;
+
+        // We do the copy in two passes -- first copying all the
+        // entries that are STORED, then copying all the entries that
+        // have any other compression flag (which in practice means
+        // DEFLATED).  This groups all the stored entries together at
+        // the start of the file and makes it easier to do alignment
+        // on them (since only stored entries are aligned).
+
+        for (String name : names) {
+            JarEntry inEntry = in.getJarEntry(name);
+            JarEntry outEntry;
+            if (inEntry.getMethod() != JarEntry.STORED) continue;
+            // Preserve the STORED method of the input entry.
+            outEntry = new JarEntry(inEntry);
+            outEntry.setTime(timestamp);
+            // Discard comment and extra fields of this entry to
+            // simplify alignment logic below and for consistency with
+            // how compressed entries are handled later.
+            outEntry.setComment(null);
+            outEntry.setExtra(null);
+
+            // 'offset' is the offset into the file at which we expect
+            // the file data to begin.  This is the value we need to
+            // make a multiple of 'alignement'.
+            offset += JarFile.LOCHDR + outEntry.getName().length();
+            if (firstEntry) {
+                // The first entry in a jar file has an extra field of
+                // four bytes that you can't get rid of; any extra
+                // data you specify in the JarEntry is appended to
+                // these forced four bytes.  This is JAR_MAGIC in
+                // JarOutputStream; the bytes are 0xfeca0000.
+                offset += 4;
+                firstEntry = false;
+            }
+            int alignment = getStoredEntryDataAlignment(name, defaultAlignment);
+            if (alignment > 0 && (offset % alignment != 0)) {
+                // Set the "extra data" of the entry to between 1 and
+                // alignment-1 bytes, to make the file data begin at
+                // an aligned offset.
+                int needed = alignment - (int) (offset % alignment);
+                outEntry.setExtra(new byte[needed]);
+                offset += needed;
+            }
+
+            out.putNextEntry(outEntry);
+
+            InputStream data = in.getInputStream(inEntry);
+            while ((num = data.read(buffer)) > 0) {
+                out.write(buffer, 0, num);
+                offset += num;
+            }
+            out.flush();
+        }
+
+        // Copy all the non-STORED entries.  We don't attempt to
+        // maintain the 'offset' variable past this point; we don't do
+        // alignment on these entries.
+
+        for (String name : names) {
+            JarEntry inEntry = in.getJarEntry(name);
+            JarEntry outEntry;
+            if (inEntry.getMethod() == JarEntry.STORED) continue;
+            // Create a new entry so that the compressed len is recomputed.
+            outEntry = new JarEntry(name);
+            outEntry.setTime(timestamp);
+            out.putNextEntry(outEntry);
+
+            InputStream data = in.getInputStream(inEntry);
+            while ((num = data.read(buffer)) > 0) {
+                out.write(buffer, 0, num);
+            }
+            out.flush();
+        }
+    }
+
+    /**
+     * Returns the multiple (in bytes) at which the provided {@code STORED} entry's data must start
+     * relative to start of file or {@code 0} if alignment of this entry's data is not important.
+     */
+    private static int getStoredEntryDataAlignment(String entryName, int defaultAlignment) {
+        if (defaultAlignment <= 0) {
+            return 0;
+        }
+
+        if (entryName.endsWith(".so")) {
+            // Align .so contents to memory page boundary to enable memory-mapped
+            // execution.
+            return 4096;
+        } else {
+            return defaultAlignment;
+        }
+    }
+
+    private static void signFile(Manifest manifest,
+                                 X509Certificate[] publicKey, PrivateKey[] privateKey,
+                                 long timestamp, JarOutputStream outputJar) throws Exception {
+        // MANIFEST.MF
+        JarEntry je = new JarEntry(JarFile.MANIFEST_NAME);
+        je.setTime(timestamp);
+        outputJar.putNextEntry(je);
+        manifest.write(outputJar);
+
+        int numKeys = publicKey.length;
+        for (int k = 0; k < numKeys; ++k) {
+            // CERT.SF / CERT#.SF
+            je = new JarEntry(numKeys == 1 ? CERT_SF_NAME :
+                    (String.format(Locale.US, CERT_SF_MULTI_NAME, k)));
+            je.setTime(timestamp);
+            outputJar.putNextEntry(je);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            writeSignatureFile(manifest, baos, getDigestAlgorithm(publicKey[k]));
+            byte[] signedData = baos.toByteArray();
+            outputJar.write(signedData);
+
+            // CERT.{EC,RSA} / CERT#.{EC,RSA}
+            final String keyType = publicKey[k].getPublicKey().getAlgorithm();
+            je = new JarEntry(numKeys == 1 ? (String.format(CERT_SIG_NAME, keyType)) :
+                    (String.format(Locale.US, CERT_SIG_MULTI_NAME, k, keyType)));
+            je.setTime(timestamp);
+            outputJar.putNextEntry(je);
+            writeSignatureBlock(new CMSProcessableByteArray(signedData),
+                    publicKey[k], privateKey[k], outputJar);
+        }
+    }
+
+    /**
+     * Converts the provided lists of private keys, their X.509 certificates, and digest algorithms
+     * into a list of APK Signature Scheme v2 {@code SignerConfig} instances.
+     */
+    private static List<ApkSignerV2.SignerConfig> createV2SignerConfigs(
+            PrivateKey[] privateKeys, X509Certificate[] certificates, String[] digestAlgorithms)
+            throws InvalidKeyException {
+        if (privateKeys.length != certificates.length) {
+            throw new IllegalArgumentException(
+                    "The number of private keys must match the number of certificates: "
+                            + privateKeys.length + " vs" + certificates.length);
+        }
+        List<ApkSignerV2.SignerConfig> result = new ArrayList<>(privateKeys.length);
+        for (int i = 0; i < privateKeys.length; i++) {
+            PrivateKey privateKey = privateKeys[i];
+            X509Certificate certificate = certificates[i];
+            PublicKey publicKey = certificate.getPublicKey();
+            String keyAlgorithm = privateKey.getAlgorithm();
+            if (!keyAlgorithm.equalsIgnoreCase(publicKey.getAlgorithm())) {
+                throw new InvalidKeyException(
+                        "Key algorithm of private key #" + (i + 1) + " does not match key"
+                                + " algorithm of public key #" + (i + 1) + ": " + keyAlgorithm
+                                + " vs " + publicKey.getAlgorithm());
+            }
+            ApkSignerV2.SignerConfig signerConfig = new ApkSignerV2.SignerConfig();
+            signerConfig.privateKey = privateKey;
+            signerConfig.certificates = Collections.singletonList(certificate);
+            List<Integer> signatureAlgorithms = new ArrayList<>(digestAlgorithms.length);
+            for (String digestAlgorithm : digestAlgorithms) {
+                try {
+                    signatureAlgorithms.add(getV2SignatureAlgorithm(keyAlgorithm, digestAlgorithm));
+                } catch (IllegalArgumentException e) {
+                    throw new InvalidKeyException(
+                            "Unsupported key and digest algorithm combination for signer #"
+                                    + (i + 1), e);
+                }
+            }
+            signerConfig.signatureAlgorithms = signatureAlgorithms;
+            result.add(signerConfig);
+        }
+        return result;
+    }
+
+    private static int getV2SignatureAlgorithm(String keyAlgorithm, String digestAlgorithm) {
+        if ("SHA-256".equalsIgnoreCase(digestAlgorithm)) {
+            if ("RSA".equalsIgnoreCase(keyAlgorithm)) {
+                // Use RSASSA-PKCS1-v1_5 signature scheme instead of RSASSA-PSS to guarantee
+                // deterministic signatures which make life easier for OTA updates (fewer files
+                // changed when deterministic signature schemes are used).
+                return ApkSignerV2.SIGNATURE_RSA_PKCS1_V1_5_WITH_SHA256;
+            } else if ("EC".equalsIgnoreCase(keyAlgorithm)) {
+                return ApkSignerV2.SIGNATURE_ECDSA_WITH_SHA256;
+            } else if ("DSA".equalsIgnoreCase(keyAlgorithm)) {
+                return ApkSignerV2.SIGNATURE_DSA_WITH_SHA256;
+            } else {
+                throw new IllegalArgumentException("Unsupported key algorithm: " + keyAlgorithm);
+            }
+        } else if ("SHA-512".equalsIgnoreCase(digestAlgorithm)) {
+            if ("RSA".equalsIgnoreCase(keyAlgorithm)) {
+                // Use RSASSA-PKCS1-v1_5 signature scheme instead of RSASSA-PSS to guarantee
+                // deterministic signatures which make life easier for OTA updates (fewer files
+                // changed when deterministic signature schemes are used).
+                return ApkSignerV2.SIGNATURE_RSA_PKCS1_V1_5_WITH_SHA512;
+            } else if ("EC".equalsIgnoreCase(keyAlgorithm)) {
+                return ApkSignerV2.SIGNATURE_ECDSA_WITH_SHA512;
+            } else if ("DSA".equalsIgnoreCase(keyAlgorithm)) {
+                return ApkSignerV2.SIGNATURE_DSA_WITH_SHA512;
+            } else {
+                throw new IllegalArgumentException("Unsupported key algorithm: " + keyAlgorithm);
+            }
+        } else {
+            throw new IllegalArgumentException("Unsupported digest algorithm: " + digestAlgorithm);
+        }
+    }
+
+    public static void sign(X509Certificate cert, PrivateKey key,
+                            JarMap inputJar, OutputStream outputStream) throws Exception {
+        int alignment = 4;
+        int hashes = 0;
+
+        X509Certificate[] publicKey = new X509Certificate[1];
+        publicKey[0] = cert;
+        hashes |= getDigestAlgorithm(publicKey[0]);
+
+        // Set all ZIP file timestamps to Jan 1 2009 00:00:00.
+        long timestamp = 1230768000000L;
+        // The Java ZipEntry API we're using converts milliseconds since epoch into MS-DOS
+        // timestamp using the current timezone. We thus adjust the milliseconds since epoch
+        // value to end up with MS-DOS timestamp of Jan 1 2009 00:00:00.
+        timestamp -= TimeZone.getDefault().getOffset(timestamp);
+
+        PrivateKey[] privateKey = new PrivateKey[1];
+        privateKey[0] = key;
+
+        // Generate, in memory, an APK signed using standard JAR Signature Scheme.
+        ByteArrayOutputStream v1SignedApkBuf = new ByteArrayOutputStream();
+        JarOutputStream outputJar = new JarOutputStream(v1SignedApkBuf);
+        // Use maximum compression for compressed entries because the APK lives forever on
+        // the system partition.
+        outputJar.setLevel(9);
+        Manifest manifest = addDigestsToManifest(inputJar, hashes);
+        copyFiles(manifest, inputJar, outputJar, timestamp, alignment);
+        signFile(manifest, publicKey, privateKey, timestamp, outputJar);
+        outputJar.close();
+        ByteBuffer v1SignedApk = ByteBuffer.wrap(v1SignedApkBuf.toByteArray());
+        v1SignedApkBuf.reset();
+
+        ByteBuffer[] outputChunks;
+        List<ApkSignerV2.SignerConfig> signerConfigs = createV2SignerConfigs(privateKey, publicKey,
+                new String[]{APK_SIG_SCHEME_V2_DIGEST_ALGORITHM});
+        outputChunks = ApkSignerV2.sign(v1SignedApk, signerConfigs);
+
+        // This assumes outputChunks are array-backed. To avoid this assumption, the
+        // code could be rewritten to use FileChannel.
+        for (ByteBuffer outputChunk : outputChunks) {
+            outputStream.write(outputChunk.array(),
+                    outputChunk.arrayOffset() + outputChunk.position(), outputChunk.remaining());
+            outputChunk.position(outputChunk.limit());
+        }
+    }
+
+    /**
+     * Write to another stream and track how many bytes have been
+     * written.
+     */
+    private static class CountOutputStream extends FilterOutputStream {
+        private int mCount;
+
+        public CountOutputStream(OutputStream out) {
+            super(out);
+            mCount = 0;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            super.write(b);
+            mCount++;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            super.write(b, off, len);
+            mCount += len;
+        }
+
+        public int size() {
+            return mCount;
+        }
+    }
+}

--- a/app/src/main/java/me/bmax/apatch/util/apksign/ZipUtils.java
+++ b/app/src/main/java/me/bmax/apatch/util/apksign/ZipUtils.java
@@ -1,0 +1,136 @@
+package me.bmax.apatch.util.apksign;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Assorted ZIP format helpers.
+ *
+ * <p>NOTE: Most helper methods operating on {@code ByteBuffer} instances expect that the byte
+ * order of these buffers is little-endian.
+ */
+public abstract class ZipUtils {
+
+    private static final int ZIP_EOCD_REC_MIN_SIZE = 22;
+    private static final int ZIP_EOCD_REC_SIG = 0x06054b50;
+    private static final int ZIP_EOCD_CENTRAL_DIR_SIZE_FIELD_OFFSET = 12;
+    private static final int ZIP_EOCD_CENTRAL_DIR_OFFSET_FIELD_OFFSET = 16;
+    private static final int ZIP_EOCD_COMMENT_LENGTH_FIELD_OFFSET = 20;
+
+    private static final int ZIP64_EOCD_LOCATOR_SIZE = 20;
+    private static final int ZIP64_EOCD_LOCATOR_SIG = 0x07064b50;
+
+    private static final int UINT16_MAX_VALUE = 0xffff;
+
+    private ZipUtils() {
+    }
+
+    /**
+     * Returns the position at which ZIP End of Central Directory record starts in the provided
+     * buffer or {@code -1} if the record is not present.
+     *
+     * <p>NOTE: Byte order of {@code zipContents} must be little-endian.
+     */
+    public static int findZipEndOfCentralDirectoryRecord(ByteBuffer zipContents) {
+        assertByteOrderLittleEndian(zipContents);
+
+        // ZIP End of Central Directory (EOCD) record is located at the very end of the ZIP archive.
+        // The record can be identified by its 4-byte signature/magic which is located at the very
+        // beginning of the record. A complication is that the record is variable-length because of
+        // the comment field.
+        // The algorithm for locating the ZIP EOCD record is as follows. We search backwards from
+        // end of the buffer for the EOCD record signature. Whenever we find a signature, we check
+        // the candidate record's comment length is such that the remainder of the record takes up
+        // exactly the remaining bytes in the buffer. The search is bounded because the maximum
+        // size of the comment field is 65535 bytes because the field is an unsigned 16-bit number.
+
+        int archiveSize = zipContents.capacity();
+        if (archiveSize < ZIP_EOCD_REC_MIN_SIZE) {
+            return -1;
+        }
+        int maxCommentLength = Math.min(archiveSize - ZIP_EOCD_REC_MIN_SIZE, UINT16_MAX_VALUE);
+        int eocdWithEmptyCommentStartPosition = archiveSize - ZIP_EOCD_REC_MIN_SIZE;
+        for (int expectedCommentLength = 0; expectedCommentLength < maxCommentLength; expectedCommentLength++) {
+            int eocdStartPos = eocdWithEmptyCommentStartPosition - expectedCommentLength;
+            if (zipContents.getInt(eocdStartPos) == ZIP_EOCD_REC_SIG) {
+                int actualCommentLength = getUnsignedInt16(zipContents, eocdStartPos + ZIP_EOCD_COMMENT_LENGTH_FIELD_OFFSET);
+                if (actualCommentLength == expectedCommentLength) {
+                    return eocdStartPos;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Returns {@code true} if the provided buffer contains a ZIP64 End of Central Directory
+     * Locator.
+     *
+     * <p>NOTE: Byte order of {@code zipContents} must be little-endian.
+     */
+    public static boolean isZip64EndOfCentralDirectoryLocatorPresent(ByteBuffer zipContents, int zipEndOfCentralDirectoryPosition) {
+        assertByteOrderLittleEndian(zipContents);
+
+        // ZIP64 End of Central Directory Locator immediately precedes the ZIP End of Central
+        // Directory Record.
+
+        int locatorPosition = zipEndOfCentralDirectoryPosition - ZIP64_EOCD_LOCATOR_SIZE;
+        if (locatorPosition < 0) {
+            return false;
+        }
+
+        return zipContents.getInt(locatorPosition) == ZIP64_EOCD_LOCATOR_SIG;
+    }
+
+    /**
+     * Returns the offset of the start of the ZIP Central Directory in the archive.
+     *
+     * <p>NOTE: Byte order of {@code zipEndOfCentralDirectory} must be little-endian.
+     */
+    public static long getZipEocdCentralDirectoryOffset(ByteBuffer zipEndOfCentralDirectory) {
+        assertByteOrderLittleEndian(zipEndOfCentralDirectory);
+        return getUnsignedInt32(zipEndOfCentralDirectory, zipEndOfCentralDirectory.position() + ZIP_EOCD_CENTRAL_DIR_OFFSET_FIELD_OFFSET);
+    }
+
+    /**
+     * Sets the offset of the start of the ZIP Central Directory in the archive.
+     *
+     * <p>NOTE: Byte order of {@code zipEndOfCentralDirectory} must be little-endian.
+     */
+    public static void setZipEocdCentralDirectoryOffset(ByteBuffer zipEndOfCentralDirectory, long offset) {
+        assertByteOrderLittleEndian(zipEndOfCentralDirectory);
+        setUnsignedInt32(zipEndOfCentralDirectory, zipEndOfCentralDirectory.position() + ZIP_EOCD_CENTRAL_DIR_OFFSET_FIELD_OFFSET, offset);
+    }
+
+    /**
+     * Returns the size (in bytes) of the ZIP Central Directory.
+     *
+     * <p>NOTE: Byte order of {@code zipEndOfCentralDirectory} must be little-endian.
+     */
+    public static long getZipEocdCentralDirectorySizeBytes(ByteBuffer zipEndOfCentralDirectory) {
+        assertByteOrderLittleEndian(zipEndOfCentralDirectory);
+        return getUnsignedInt32(zipEndOfCentralDirectory, zipEndOfCentralDirectory.position() + ZIP_EOCD_CENTRAL_DIR_SIZE_FIELD_OFFSET);
+    }
+
+    private static void assertByteOrderLittleEndian(ByteBuffer buffer) {
+        if (buffer.order() != ByteOrder.LITTLE_ENDIAN) {
+            throw new IllegalArgumentException("ByteBuffer byte order must be little endian");
+        }
+    }
+
+    private static int getUnsignedInt16(ByteBuffer buffer, int offset) {
+        return buffer.getShort(offset) & 0xffff;
+    }
+
+    private static long getUnsignedInt32(ByteBuffer buffer, int offset) {
+        return buffer.getInt(offset) & 0xffffffffL;
+    }
+
+    private static void setUnsignedInt32(ByteBuffer buffer, int offset, long value) {
+        if ((value < 0) || (value > 0xffffffffL)) {
+            throw new IllegalArgumentException("uint32 value of out range: " + value);
+        }
+        buffer.putInt(buffer.position() + offset, (int) value);
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,4 +147,11 @@
     <string name="apm_downloading">Downloading \"%s\" module…</string>
     <string name="apm_start_downloading">Start downloading %s</string>
     <string name="apm_new_version_available">Click to install the new version, %s.</string>
+
+    <string name="hide_apatch_manager">Hide APatch Manager</string>
+    <string name="hide_apatch_manager_summary">Install a new manager app with a random package ID and custom app label</string>
+    <string name="hide_apatch_dialog_new_manager_name">New Manager Name</string>
+    <string name="hide_apatch_dialog_summary">It will be used as the new app label shown in launcher</string>
+    <string name="hide_apatch_manager_failure">Failed to hide, please report the bug!</string>
+
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,3 +67,4 @@ markdown = { group = "io.noties.markwon", name = "core", version.ref = "markdown
 timber = { group = "com.jakewharton.timber", name = "timber", version = "5.0.1" }
 devappx = { group = "io.github.afkt", name = "DevAppX", version = "2.4.4" }
 ini4j = { group = "org.ini4j", name = "ini4j", version = "0.5.4" }
+bcpkix = { group = "org.bouncycastle", name = "bcpkix-jdk18on", version = "1.77" }


### PR DESCRIPTION
[feature] manager: Introduce Hide APatch Manager

Since apps can detect APatch via its manager's packageName, whether it has the permission
to read app list or not, exposing original manager packageName is dangerous. Here is a
simple method to generate a new random packageName and customized name manager to bypass
the check.

#222 also required this feature.

Credit: topjohwnu's Magisk about apksign's codes and some good ideas.