### PR TITLE
manager: Fix unable to enter superkey

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
@@ -113,10 +113,10 @@ fun AuthSuperKey(showDialog: MutableState<Boolean>) {
                         value = key,
                         onValueChange = {
                             key = it
-                            enable = !key.isEmpty() },
+                            enable = key.isNotEmpty()
+                        },
                         label = { Text(stringResource(id = R.string.super_key)) },
                         visualTransformation = if (keyVisible) VisualTransformation.None else PasswordVisualTransformation(),
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
                     )
                     IconButton(
                         modifier = Modifier


### PR DESCRIPTION
During my tests, setting keyboardType to KeyboardType.Password made it
unable to enter superkey. Maybe it was something wrong in latest deps.
Instead of finding a better solution, temporarily removing keyboardType
is a good idea until we fix it.