### PR TITLE
The `boot_extract.sh` file adds one additional condition check.

### DIFF
--- a/app/src/main/assets/boot_extract.sh
+++ b/app/src/main/assets/boot_extract.sh
@@ -7,7 +7,7 @@ ARCH=$(getprop ro.product.cpu.abi)
 
 mount_partitions
 
-[ -z $SLOT ] && { >&2 echo "- can't determined current boot slot!"; exit 1; }
+[ -z "$SLOT" ] && [ -n "$( find_block boot_a )" ] && { >&2 echo "- can't determined current boot slot!"; exit 1; }
 
 find_boot_image
 


### PR DESCRIPTION
a only的分区肯定找不到slot，应该多加一个判断，应该是有boot_a之类分区的找不到插槽再报错

From Telegram@Josh