### PR TITLE
Refine flash_image function for enhanced Image flashing operations

### DIFF
--- a/app/src/main/assets/util_functions.sh
+++ b/app/src/main/assets/util_functions.sh
@@ -107,27 +107,27 @@ find_boot_image() {
 }
 
 flash_image() {
-  local CMD1
-  case "$1" in
-    *.gz) CMD1="gzip -d < '$1' 2>/dev/null";;
-    *)    CMD1="cat '$1'";;
-  esac
-  if [ -b "$2" ]; then
-    local img_sz=$(stat -c '%s' "$1")
-    local blk_sz=$(blockdev --getsize64 "$2")
-    [ "$img_sz" -gt "$blk_sz" ] && return 1
-    blockdev --setrw "$2"
-    local blk_ro=$(blockdev --getro "$2")
-    [ "$blk_ro" -eq 1 ] && return 2
-    ## todo: https://github.com/bmax121/APatch/pull/247
-    eval "$CMD1" > "$2" 2>/dev/null
-    eval "$CMD1" | cat - /dev/zero > "$2" 2>/dev/null
-  elif [ -c "$2" ]; then
-    flash_eraseall "$2" >&2
-    eval "$CMD1" | nandwrite -p "$2" - >&2
-  else
-    echo "- Not block or char device"
-    eval "$CMD1" > "$2" 2>/dev/null
-  fi
-  return 0
+    local CMD1
+    case "$1" in
+        *.gz) CMD1="gzip -d < '$1' 2>/dev/null";;
+        *)    CMD1="cat '$1'";;
+    esac
+    if [ -b "$2" ]; then {
+        local img_sz=$(stat -c '%s' "$1")
+        local blk_sz=$(blockdev --getsize64 "$2")
+        local blk_bs=$(blockdev --getbsz "$2")
+        [ "$img_sz" -gt "$blk_sz" ] && return 1
+        blockdev --setrw "$2"
+        local blk_ro=$(blockdev --getro "$2")
+        [ "$blk_ro" -eq 1 ] && return 2
+        eval "$CMD1" | dd of="$2" bs="$blk_bs" iflag=fullblock conv=notrunc,fsync 2>/dev/null
+        sync
+    } elif [ -c "$2" ]; then {
+        flash_eraseall "$2" >&2
+        eval "$CMD1" | nandwrite -p "$2" - >&2
+    } else {
+        echo "- Not block or char device, storing image"
+        eval "$CMD1" > "$2" 2>/dev/null
+    } fi
+    return 0
 }


### PR DESCRIPTION
- Replace direct image writing with `dd` command utilizing block size parameter for optimized block device operations.
- Ensure complete block reads and data integrity by incorporating `iflag=fullblock` and `conv=notrunc,fsync` options in `dd`.
- Eliminate the previous method of zero-padding to prevent potential incomplete flashing.
- Execute `sync` post-write to guarantee all data is properly flushed to the device.
- Provide detailed user feedback for non-block or char device scenarios, enhancing clarity.

Fixes: https://github.com/bmax121/APatch/pull/247#issuecomment-1980231945