### PR TITLE
manager: optimize theme settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -208,9 +208,6 @@ dependencies {
     implementation(libs.com.google.accompanist.drawablepainter)
     implementation(libs.com.google.accompanist.navigation.animation)
 
-    implementation(libs.compose.destinations.animations.core)
-    ksp(libs.compose.destinations.ksp)
-
     implementation(libs.com.github.topjohnwu.libsu.core)
     implementation(libs.com.github.topjohnwu.libsu.service)
     implementation(libs.com.github.topjohnwu.libsu.nio)

--- a/app/src/main/java/me/bmax/apatch/ui/MainActivity.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/MainActivity.kt
@@ -65,7 +65,7 @@ class MainActivity : AppCompatActivity() {
 
         setContent {
             val uiViewModel = viewModel<UIViewModel>()
-            APatchTheme {
+            APatchTheme(uiViewModel) {
                 val navController = rememberNavController()
                 val snackBarHostState = remember { SnackbarHostState() }
 
@@ -91,7 +91,7 @@ class MainActivity : AppCompatActivity() {
                             composable(route = "SuperUser") { SuperUserScreen() }
                             composable(route = "APModule") { APModuleScreen(navController, uiViewModel) }
                             composable(route = "Install") { InstallScreen(navController, uiViewModel) }
-                            composable(route = "Setting") { SettingScreen() }
+                            composable(route = "Setting") { SettingScreen(uiViewModel) }
                         }
                     }
                 }

--- a/app/src/main/java/me/bmax/apatch/ui/screen/APM.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/APM.kt
@@ -64,8 +64,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import androidx.navigation.NavHostController
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -79,16 +78,16 @@ import me.bmax.apatch.ui.component.ModuleStateIndicator
 import me.bmax.apatch.ui.component.ModuleUpdateButton
 import me.bmax.apatch.ui.component.rememberConfirmDialog
 import me.bmax.apatch.ui.component.rememberLoadingDialog
-import me.bmax.apatch.ui.screen.destinations.InstallScreenDestination
 import me.bmax.apatch.ui.viewmodel.APModuleViewModel
+import me.bmax.apatch.ui.viewmodel.UIViewModel
 import me.bmax.apatch.util.DownloadListener
-import me.bmax.apatch.util.ui.LocalSnackbarHost
 import me.bmax.apatch.util.download
 import me.bmax.apatch.util.getRootShell
 import me.bmax.apatch.util.hasMagisk
 import me.bmax.apatch.util.reboot
 import me.bmax.apatch.util.shellForResult
 import me.bmax.apatch.util.toggleModule
+import me.bmax.apatch.util.ui.LocalSnackbarHost
 import me.bmax.apatch.util.uninstallModule
 import okhttp3.OkHttpClient
 
@@ -99,9 +98,8 @@ private fun getSafeMode(): Boolean {
     ).out.contains("IS_SAFE_MODE")
 }
 
-@Destination
 @Composable
-fun APModuleScreen(navigator: DestinationsNavigator) {
+fun APModuleScreen(navController: NavHostController, uiViewModel: UIViewModel) {
     val context = LocalContext.current
 
     val state by APApplication.apStateLiveData.observeAsState(APApplication.State.UNKNOWN_STATE)
@@ -156,7 +154,8 @@ fun APModuleScreen(navigator: DestinationsNavigator) {
 
                 Log.i("ModuleScreen", "select zip result: $uri")
 
-                navigator.navigate(InstallScreenDestination(uri))
+                uiViewModel.apModuleUri = uri
+                navController.navigate("Install")
 
                 viewModel.markNeedRefresh()
             }
@@ -198,7 +197,8 @@ fun APModuleScreen(navigator: DestinationsNavigator) {
                         .fillMaxSize(),
                     state = moduleListState,
                     onInstallModule = {
-                        navigator.navigate(InstallScreenDestination(it))
+                        uiViewModel.apModuleUri = it
+                        navController.navigate("Install")
                     },
                     onClickModule = { id, name, hasWebUi ->
                         if (hasWebUi) {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/AboutScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/AboutScreen.kt
@@ -34,16 +34,14 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.res.ResourcesCompat
+import androidx.navigation.NavHostController
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
-import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import me.bmax.apatch.BuildConfig
 import me.bmax.apatch.R
 import me.bmax.apatch.util.Version
 
-@Destination
 @Composable
-fun AboutScreen(navigator: DestinationsNavigator) {
+fun AboutScreen(navController: NavHostController) {
     val uriHandler = LocalUriHandler.current
     val drawable = ResourcesCompat.getDrawable(
         LocalContext.current.resources,
@@ -53,7 +51,7 @@ fun AboutScreen(navigator: DestinationsNavigator) {
 
     Scaffold(
         topBar = {
-            TopBar(onBack = { navigator.popBackStack() })
+            TopBar(onBack = { navController.popBackStack() })
         }) { innerPadding ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/me/bmax/apatch/ui/screen/BottomBarDestination.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/BottomBarDestination.kt
@@ -13,16 +13,10 @@ import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
-import com.ramcosta.composedestinations.spec.DirectionDestinationSpec
 import me.bmax.apatch.R
-import me.bmax.apatch.ui.screen.destinations.APModuleScreenDestination
-import me.bmax.apatch.ui.screen.destinations.HomeScreenDestination
-import me.bmax.apatch.ui.screen.destinations.KPModuleScreenDestination
-import me.bmax.apatch.ui.screen.destinations.SettingScreenDestination
-import me.bmax.apatch.ui.screen.destinations.SuperUserScreenDestination
 
 enum class BottomBarDestination(
-    val direction: DirectionDestinationSpec,
+    val direction: String,
     @StringRes val label: Int,
     val iconSelected: ImageVector,
     val iconNotSelected: ImageVector,
@@ -30,7 +24,7 @@ enum class BottomBarDestination(
     val aPatchRequired: Boolean,
 ) {
     Home(
-        HomeScreenDestination,
+        "Home",
         R.string.home,
         Icons.Filled.Home,
         Icons.Outlined.Home,
@@ -38,7 +32,7 @@ enum class BottomBarDestination(
         false
     ),
     KModule(
-        KPModuleScreenDestination,
+        "KPModule",
         R.string.kpm,
         Icons.Filled.Build,
         Icons.Outlined.Build,
@@ -46,7 +40,7 @@ enum class BottomBarDestination(
         false
     ),
     SuperUser(
-        SuperUserScreenDestination,
+        "SuperUser",
         R.string.su_title,
         Icons.Filled.Security,
         Icons.Outlined.Security,
@@ -54,7 +48,7 @@ enum class BottomBarDestination(
         false
     ),
     AModule(
-        APModuleScreenDestination,
+        "APModule",
         R.string.apm,
         Icons.Filled.Apps,
         Icons.Outlined.Apps,
@@ -62,7 +56,7 @@ enum class BottomBarDestination(
         true
     ),
     Settings(
-        SettingScreenDestination,
+        "Setting",
         R.string.settings,
         Icons.Filled.Settings,
         Icons.Outlined.Settings,

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Install.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Install.kt
@@ -1,6 +1,5 @@
 package me.bmax.apatch.ui.screen
 
-import android.net.Uri
 import android.os.Environment
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -33,27 +32,27 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import androidx.navigation.NavHostController
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.bmax.apatch.R
 import me.bmax.apatch.ui.component.KeyEventBlocker
-import me.bmax.apatch.util.ui.LocalSnackbarHost
+import me.bmax.apatch.ui.viewmodel.UIViewModel
 import me.bmax.apatch.util.installModule
 import me.bmax.apatch.util.reboot
+import me.bmax.apatch.util.ui.LocalSnackbarHost
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
 @Composable
-@Destination
-fun InstallScreen(navigator: DestinationsNavigator, uri: Uri) {
+fun InstallScreen(navController: NavHostController, uiViewModel: UIViewModel) {
     var text by rememberSaveable { mutableStateOf("") }
     val logContent = rememberSaveable { StringBuilder() }
     var showFloatAction by rememberSaveable { mutableStateOf(false) }
+    val uri = uiViewModel.apModuleUri
 
     val snackBarHost = LocalSnackbarHost.current
     val scope = rememberCoroutineScope()
@@ -81,7 +80,7 @@ fun InstallScreen(navigator: DestinationsNavigator, uri: Uri) {
         topBar = {
             TopBar(
                 onBack = {
-                    navigator.popBackStack()
+                    navController.popBackStack()
                 },
                 onSave = {
                     scope.launch {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/InstallModeSelect.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/InstallModeSelect.kt
@@ -29,27 +29,25 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import androidx.navigation.NavHostController
 import me.bmax.apatch.R
 import me.bmax.apatch.ui.component.rememberConfirmDialog
-import me.bmax.apatch.ui.screen.destinations.PatchesDestination
 import me.bmax.apatch.ui.viewmodel.PatchesViewModel
+import me.bmax.apatch.ui.viewmodel.UIViewModel
 import me.bmax.apatch.util.isABDevice
 import me.bmax.apatch.util.rootAvailable
 
 var selectedBootImage: Uri? = null
 
-@Destination
 @Composable
-fun InstallModeSelectScreen(navigator: DestinationsNavigator) {
+fun InstallModeSelectScreen(navController: NavHostController, uiViewModel: UIViewModel) {
     var installMethod by remember {
         mutableStateOf<InstallMethod?>(null)
     }
 
     Scaffold(topBar = {
         TopBar(
-            onBack = { navigator.popBackStack() },
+            onBack = { navController.popBackStack() },
         )
     }) {
         Column(modifier = Modifier.padding(it)) {
@@ -57,7 +55,8 @@ fun InstallModeSelectScreen(navigator: DestinationsNavigator) {
                 onSelected = { method ->
                     installMethod = method
                 },
-                navigator = navigator
+                navController = navController,
+                uiViewModel = uiViewModel
             )
 
         }
@@ -87,7 +86,8 @@ sealed class InstallMethod {
 @Composable
 private fun SelectInstallMethod(
     onSelected: (InstallMethod) -> Unit = {},
-    navigator: DestinationsNavigator
+    navController: NavHostController,
+    uiViewModel: UIViewModel
 ) {
     val rootAvailable = rootAvailable()
     val isAbDevice = isABDevice()
@@ -111,7 +111,8 @@ private fun SelectInstallMethod(
                 selectedOption = option
                 onSelected(option)
                 selectedBootImage = option.uri
-                navigator.navigate(PatchesDestination(PatchesViewModel.PatchMode.PATCH_ONLY))
+                uiViewModel.patchMode = PatchesViewModel.PatchMode.PATCH_ONLY
+                navController.navigate("Patches")
             }
         }
     }
@@ -119,7 +120,8 @@ private fun SelectInstallMethod(
     val confirmDialog = rememberConfirmDialog(onConfirm = {
         selectedOption = InstallMethod.DirectInstallToInactiveSlot
         onSelected(InstallMethod.DirectInstallToInactiveSlot)
-        navigator.navigate(PatchesDestination(PatchesViewModel.PatchMode.INSTALL_TO_NEXT_SLOT))
+        uiViewModel.patchMode = PatchesViewModel.PatchMode.INSTALL_TO_NEXT_SLOT
+        navController.navigate("Patches")
     }, onDismiss = null)
     val dialogTitle = stringResource(id = android.R.string.dialog_alert_title)
     val dialogContent = stringResource(id = R.string.mode_select_page_install_inactive_slot_warning)
@@ -139,7 +141,8 @@ private fun SelectInstallMethod(
             is InstallMethod.DirectInstall -> {
                 selectedOption = option
                 onSelected(option)
-                navigator.navigate(PatchesDestination(PatchesViewModel.PatchMode.PATCH_AND_INSTALL))
+                uiViewModel.patchMode = PatchesViewModel.PatchMode.PATCH_AND_INSTALL
+                navController.navigate("Patches")
             }
 
             is InstallMethod.DirectInstallToInactiveSlot -> {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/KPM.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/KPM.kt
@@ -72,8 +72,7 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import androidx.compose.ui.window.PopupProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import androidx.navigation.NavHostController
 import com.topjohnwu.superuser.nio.ExtendedFile
 import com.topjohnwu.superuser.nio.FileSystemManager
 import kotlinx.coroutines.Dispatchers
@@ -89,21 +88,20 @@ import me.bmax.apatch.ui.component.LoadingDialogHandle
 import me.bmax.apatch.ui.component.ProvideMenuShape
 import me.bmax.apatch.ui.component.rememberConfirmDialog
 import me.bmax.apatch.ui.component.rememberLoadingDialog
-import me.bmax.apatch.ui.screen.destinations.PatchesDestination
 import me.bmax.apatch.ui.viewmodel.KPModel
 import me.bmax.apatch.ui.viewmodel.KPModuleViewModel
 import me.bmax.apatch.ui.viewmodel.PatchesViewModel
-import me.bmax.apatch.util.ui.APDialogBlurBehindUtils
+import me.bmax.apatch.ui.viewmodel.UIViewModel
 import me.bmax.apatch.util.inputStream
+import me.bmax.apatch.util.ui.APDialogBlurBehindUtils
 import me.bmax.apatch.util.writeTo
 import java.io.IOException
 
 private const val TAG = "KernelPatchModule"
 private lateinit var targetKPMToControl: KPModel.KPMInfo
 
-@Destination
 @Composable
-fun KPModuleScreen(navigator: DestinationsNavigator) {
+fun KPModuleScreen(navController: NavHostController, uiViewModel: UIViewModel) {
     val state by APApplication.apStateLiveData.observeAsState(APApplication.State.UNKNOWN_STATE)
     if (state == APApplication.State.UNKNOWN_STATE) {
         Column(
@@ -199,7 +197,8 @@ fun KPModuleScreen(navigator: DestinationsNavigator) {
                                 expanded = false
                                 when (label) {
                                     moduleEmbed -> {
-                                        navigator.navigate(PatchesDestination(PatchesViewModel.PatchMode.PATCH_AND_INSTALL))
+                                        uiViewModel.patchMode = PatchesViewModel.PatchMode.PATCH_AND_INSTALL
+                                        navController.navigate("Patches")
                                     }
 
                                     moduleInstall -> {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Patches.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Patches.kt
@@ -25,9 +25,6 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
@@ -35,11 +32,14 @@ import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -61,7 +61,6 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.ramcosta.composedestinations.annotation.Destination
 import dev.utils.app.permission.PermissionUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -69,17 +68,18 @@ import kotlinx.coroutines.withContext
 import me.bmax.apatch.R
 import me.bmax.apatch.ui.viewmodel.KPModel
 import me.bmax.apatch.ui.viewmodel.PatchesViewModel
+import me.bmax.apatch.ui.viewmodel.UIViewModel
 import me.bmax.apatch.util.Version
 import me.bmax.apatch.util.reboot
 
 private const val TAG = "Patches"
 
-@Destination
 @Composable
-fun Patches(mode: PatchesViewModel.PatchMode) {
+fun Patches(uiViewModel: UIViewModel) {
     val permissionRequest = remember { mutableStateOf(false) }
     val scrollState = rememberScrollState()
     val scope = rememberCoroutineScope()
+    val mode = uiViewModel.patchMode
 
     val viewModel = viewModel<PatchesViewModel>()
     SideEffect {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Settings.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Settings.kt
@@ -67,7 +67,6 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.content.FileProvider
 import androidx.core.os.LocaleListCompat
-import com.ramcosta.composedestinations.annotation.Destination
 import dev.utils.app.AppUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -87,7 +86,6 @@ import me.bmax.apatch.util.setGlobalNamespaceEnabled
 import me.bmax.apatch.util.ui.APDialogBlurBehindUtils
 import java.util.Locale
 
-@Destination
 @Composable
 fun SettingScreen() {
     val state by APApplication.apStateLiveData.observeAsState(APApplication.State.UNKNOWN_STATE)

--- a/app/src/main/java/me/bmax/apatch/ui/screen/SuperUser.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/SuperUser.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.ramcosta.composedestinations.annotation.Destination
 import kotlinx.coroutines.launch
 import me.bmax.apatch.Natives
 import me.bmax.apatch.R
@@ -59,7 +58,6 @@ import me.bmax.apatch.util.PkgConfig
 
 
 @OptIn(ExperimentalMaterialApi::class)
-@Destination
 @Composable
 fun SuperUserScreen() {
     val viewModel = viewModel<SuperUserViewModel>()

--- a/app/src/main/java/me/bmax/apatch/ui/theme/Theme.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/theme/Theme.kt
@@ -1,11 +1,11 @@
 package me.bmax.apatch.ui.theme
 
-import android.content.Context
 import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import me.bmax.apatch.APApplication
+import me.bmax.apatch.ui.viewmodel.UIViewModel
 
 @Composable
 private fun SystemBarStyle(
@@ -46,25 +47,27 @@ private fun SystemBarStyle(
 
 @Composable
 fun APatchTheme(
+    uiViewModel: UIViewModel,
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
     val prefs = APApplication.sharedPreferences
-    val darkTheme = if (prefs.getBoolean("night_mode_follow_sys", true)) {
+    uiViewModel.nightFollowSystem = prefs.getBoolean("night_mode_follow_sys", true)
+    uiViewModel.darkTheme = if (uiViewModel.nightFollowSystem) {
         isSystemInDarkTheme()
     } else {
         prefs.getBoolean("night_mode_enabled", false)
     }
     // Dynamic color is available on Android 12+, and custom 1t!
-    val dynamicColor = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) prefs.getBoolean(
+    uiViewModel.dynamicColor = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) prefs.getBoolean(
         "use_system_color_theme", true
     ) else false
 
-    val customColorScheme = prefs.getString("custom_color", "blue")
+    uiViewModel.customColorScheme = prefs.getString("custom_color", "blue")!!
 
-    val colorScheme = if (!dynamicColor) {
-        if (darkTheme) {
-            when (customColorScheme) {
+    val colorScheme = if (!uiViewModel.dynamicColor) {
+        if (uiViewModel.darkTheme) {
+            when (uiViewModel.customColorScheme) {
                 "amber" -> DarkAmberTheme
                 "blue_grey" -> DarkBlueGreyTheme
                 "blue" -> DarkBlueTheme
@@ -87,7 +90,7 @@ fun APatchTheme(
                 else -> DarkBlueTheme
             }
         } else {
-            when (customColorScheme) {
+            when (uiViewModel.customColorScheme) {
                 "amber" -> LightAmberTheme
                 "blue_grey" -> LightBlueGreyTheme
                 "blue" -> LightBlueTheme
@@ -113,16 +116,16 @@ fun APatchTheme(
     } else {
         when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+                if (uiViewModel.darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
             }
 
-            darkTheme -> DarkBlueTheme
+            uiViewModel.darkTheme -> DarkBlueTheme
             else -> LightBlueTheme
         }
     }
 
     SystemBarStyle(
-        darkMode = darkTheme
+        darkMode = uiViewModel.darkTheme
     )
 
     MaterialTheme(

--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/UIViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/UIViewModel.kt
@@ -1,10 +1,17 @@
 package me.bmax.apatch.ui.viewmodel
 
 import android.net.Uri
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 
 class UIViewModel: ViewModel() {
     var patchMode = PatchesViewModel.PatchMode.PATCH_ONLY
-
     lateinit var apModuleUri: Uri
+
+    var darkTheme by mutableStateOf(false)
+    var nightFollowSystem by mutableStateOf(true)
+    var dynamicColor by mutableStateOf(true)
+    var customColorScheme: String by mutableStateOf("blue")
 }

--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/UIViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/UIViewModel.kt
@@ -1,0 +1,10 @@
+package me.bmax.apatch.ui.viewmodel
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+
+class UIViewModel: ViewModel() {
+    var patchMode = PatchesViewModel.PatchMode.PATCH_ONLY
+
+    lateinit var apModuleUri: Uri
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ compose-bom = "2024.05.00"
 lifecycle = "2.8.0"
 accompanist = "0.34.0"
 navigation = "2.7.7"
-compose-destination = "1.10.2"
 libsu = "5.2.2"
 sheets-compose-dialogs = "1.3.0"
 markdown = "4.6.2"
@@ -59,9 +58,6 @@ io-coil-kt-coil-compose = { group = "io.coil-kt", name = "coil-compose", version
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.8.1" }
 
 me-zhanghai-android-appiconloader-coil = { group = "me.zhanghai.android.appiconloader", name = "appiconloader-coil", version = "1.5.0" }
-
-compose-destinations-animations-core = { group = "io.github.raamcosta.compose-destinations", name = "animations-core", version.ref = "compose-destination" }
-compose-destinations-ksp = { group = "io.github.raamcosta.compose-destinations", name = "ksp", version.ref = "compose-destination" }
 
 sheet-compose-dialogs-core = { group = "com.maxkeppeler.sheets-compose-dialogs", name = "core", version.ref = "sheets-compose-dialogs"}
 sheet-compose-dialogs-list = { group = "com.maxkeppeler.sheets-compose-dialogs", name = "list", version.ref = "sheets-compose-dialogs"}


### PR DESCRIPTION
- 使用androidx的compose-navigation代替compose-destination库作为导航方式
- 创建uiViewModel类，使用MutableState保存主题相关状态，在`APatchTheme()`中使用这些状态判断使用的主题
- 在修改主题时修改uiViewModel中的状态，避免`recreate()`
- 简化了主题选择器的代码，重复的部分使用`items()`代替`item()`