### PR TITLE
Correct grammar

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/KPM.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/KPM.kt
@@ -204,7 +204,7 @@ fun KPModuleScreen(navigator: DestinationsNavigator) {
 
                                     moduleInstall -> {
                                         Toast.makeText(
-                                            current, "Not support now!", Toast.LENGTH_SHORT
+                                            current, "Not supported yet!", Toast.LENGTH_SHORT
                                         ).show()
                                     }
 


### PR DESCRIPTION
Original string: "No support now!"
Proposed string: "Not supported yet!"

The phrase "not supported yet" is used it to indicate that a certain item, service, feature, or option is not yet available. For example, "This feature is not supported yet but it should be available soon.".
