### PR TITLE
manager, README: Correct the domain for document

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To help translate APatch or improve existing translations, please use [Weblate](
 
 ### Usage
 
-For usage, please refer to [our official documentation](https://apatch.top).  
+For usage, please refer to [our official documentation](https://apatch.dev).  
 It's worth noting that the documentation is currently not quite complete, and the content may change at any time.  
 Furthermore, we need more volunteers to [contribute to the documentation](https://github.com/AndroidPatch/APatchDocs) in other languages.
 

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
@@ -983,7 +983,7 @@ fun LearnMoreCard() {
         Row(modifier = Modifier
             .fillMaxWidth()
             .clickable {
-                uriHandler.openUri("https://apatch.top")
+                uriHandler.openUri("https://apatch.dev")
             }
             .padding(24.dp), verticalAlignment = Alignment.CenterVertically) {
             Column {


### PR DESCRIPTION
昨天APatch的官方文档地址从<https://apatch.top>换成了<https://apatch.dev>[1]，故修改README和App本体内的文档指向域名

[1] https://github.com/AndroidPatch/APatchDocs/commit/fe111016dda2b64f06f93af6caf34f6d132a455a