### PR TITLE
manager: Add flash script into APatch Manager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,7 +80,16 @@ android {
             useLegacyPackaging = true
         }
         resources {
-            excludes += "**"
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            excludes += "/META-INF/**.version"
+            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
+            excludes += "okhttp3/**"
+            excludes += "kotlin/**"
+            excludes += "/org/bouncycastle/**"
+            excludes += "org/**"
+            excludes += "**.properties"
+            excludes += "**.bin"
+            excludes += "kotlin-tooling-metadata.json"
         }
     }
 
@@ -171,9 +180,14 @@ tasks.register<Copy>("mergeFlashableScript") {
     from(rootProject.file("${project.rootDir}/scripts/update_binary.sh")) {
         rename { "update-binary" }
     }
-    from(rootProject.file("${project.rootDir}/scripts/update_binary.sh")) {
+    from(rootProject.file("${project.rootDir}/scripts/update_script.sh")) {
         rename { "updater-script" }
     }
+}
+
+tasks.register<Copy>("mergeInstallAP") {
+    into("${project.projectDir}/src/main/resources/addon")
+    from(rootProject.file("${project.rootDir}/scripts/InstallAP.sh"))
 }
 
 tasks.getByName("preBuild").dependsOn(
@@ -181,6 +195,7 @@ tasks.getByName("preBuild").dependsOn(
     "downloadKptools",
     "downloadCompatKpatch",
     "mergeFlashableScript",
+    "mergeInstallAP",
 )
 
 // https://github.com/bbqsrc/cargo-ndk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -185,9 +185,10 @@ tasks.register<Copy>("mergeFlashableScript") {
     }
 }
 
-tasks.register<Copy>("mergeInstallAP") {
+tasks.register<Copy>("mergeAPScript") {
     into("${project.projectDir}/src/main/resources/addon")
     from(rootProject.file("${project.rootDir}/scripts/InstallAP.sh"))
+    from(rootProject.file("${project.rootDir}/scripts/UninstallAP.sh"))
 }
 
 tasks.getByName("preBuild").dependsOn(
@@ -195,7 +196,7 @@ tasks.getByName("preBuild").dependsOn(
     "downloadKptools",
     "downloadCompatKpatch",
     "mergeFlashableScript",
-    "mergeInstallAP",
+    "mergeAPScript",
 )
 
 // https://github.com/bbqsrc/cargo-ndk

--- a/scripts/InstallAP.sh
+++ b/scripts/InstallAP.sh
@@ -15,7 +15,7 @@ function ui_printfile() {
 
 function apatchNote(){
 	ui_print "- Apatch Patch Done"
-	ui_print "- Apatch Key is apatch66"
+	ui_print "- Apatch Key is $skey"
 	ui_print "- We do have saved Origin Boot image to /data"
 	ui_print "- If you encounter bootloop, reboot into Recovery and flash it"
 	exit
@@ -32,7 +32,7 @@ function boot_execute_ab(){
 	./lib/arm64-v8a/libmagiskboot.so unpack boot.img
 	mv kernel kernel-origin
 	# ./lib/arm64-v8a/libkptools.so boot-patch -b boot.img --magiskboot ./lib/arm64-v8a/libmagiskboot.so >> /dev/tmp/install/log
-	./lib/arm64-v8a/libkptools.so -p --image kernel-origin --skey "apatch66" --kpimg ./assets/kpimg --out ./kernel >> /dev/tmp/install/log
+	./lib/arm64-v8a/libkptools.so -p --image kernel-origin --skey "$skey" --kpimg ./assets/kpimg --out ./kernel >> /dev/tmp/install/log
 	if [[ ! "$?" == 0 ]]; then
 		failed
 	fi
@@ -47,7 +47,7 @@ function boot_execute(){
 	./lib/arm64-v8a/libmagiskboot.so unpack boot.img
 	mv kernel kernel-origin
 	# ./lib/arm64-v8a/libkptools.so boot-patch -b boot.img --magiskboot ./lib/arm64-v8a/libmagiskboot.so >> /dev/tmp/install/log
-	./lib/arm64-v8a/libkptools.so -p --image kernel-origin --skey "apatch66" --kpimg ./assets/kpimg --out ./kernel >> /dev/tmp/install/log
+	./lib/arm64-v8a/libkptools.so -p --image kernel-origin --skey "$skey" --kpimg ./assets/kpimg --out ./kernel >> /dev/tmp/install/log
 	if [[ ! "$?" == 0 ]]; then
 		failed
 	fi
@@ -68,10 +68,15 @@ chmod a+x ./lib/arm64-v8a/libmagiskboot.so
 
 slot=$(getprop ro.boot.slot_suffix)
 
+skey=$(cat /proc/sys/kernel/random/uuid | cut -d \- -f1)
+
 if [[ ! "$slot" == "" ]]; then
 
 	ui_print ""
 	ui_print "- You are using A/B device."
+
+	# Script author
+	ui_print "- Install Script by SakuraKyuo"
 
 	# Get kernel
 	ui_print ""

--- a/scripts/InstallAP.sh
+++ b/scripts/InstallAP.sh
@@ -1,0 +1,100 @@
+#!/sbin/bash
+# By SakuraKyuo
+
+OUTFD=$1
+
+function ui_print() {
+  echo -e "ui_print $1\nui_print" >> $OUTFD
+}
+
+function ui_printfile() {
+  while IFS='' read -r line || $BB [[ -n "$line" ]]; do
+    ui_print "$line";
+  done < $1;
+}
+
+function apatchNote(){
+	ui_print "- Apatch Patch Done"
+	ui_print "- Apatch Key is apatch66"
+	ui_print "- We do have saved Origin Boot image to /data"
+	ui_print "- If you encounter bootloop, reboot into Recovery and flash it"
+	exit
+}
+
+function failed(){
+	ui_printfile /dev/tmp/install/log
+	ui_print "- APatch Patch Failed."
+	ui_print "- Please feedback to the developer with the screenshots."
+	exit
+}
+
+function boot_execute_ab(){
+	./lib/arm64-v8a/libmagiskboot.so unpack boot.img
+	mv kernel kernel-origin
+	# ./lib/arm64-v8a/libkptools.so boot-patch -b boot.img --magiskboot ./lib/arm64-v8a/libmagiskboot.so >> /dev/tmp/install/log
+	./lib/arm64-v8a/libkptools.so -p --image kernel-origin --skey "apatch66" --kpimg ./assets/kpimg --out ./kernel >> /dev/tmp/install/log
+	if [[ ! "$?" == 0 ]]; then
+		failed
+	fi
+	ui_printfile /dev/tmp/install/log
+	./lib/arm64-v8a/libmagiskboot.so repack boot.img
+	dd if=/dev/tmp/install/new-boot.img of=/dev/block/by-name/boot$slot
+	mv boot.img /data/boot.img
+	apatchNote
+}
+
+function boot_execute(){
+	./lib/arm64-v8a/libmagiskboot.so unpack boot.img
+	mv kernel kernel-origin
+	# ./lib/arm64-v8a/libkptools.so boot-patch -b boot.img --magiskboot ./lib/arm64-v8a/libmagiskboot.so >> /dev/tmp/install/log
+	./lib/arm64-v8a/libkptools.so -p --image kernel-origin --skey "apatch66" --kpimg ./assets/kpimg --out ./kernel >> /dev/tmp/install/log
+	if [[ ! "$?" == 0 ]]; then
+		failed
+	fi
+	ui_printfile /dev/tmp/install/log
+	./lib/arm64-v8a/libmagiskboot.so repack boot.img
+	dd if=/dev/tmp/install/new-boot.img of=/dev/block/by-name/boot$slot
+	mv boot.img /data/boot.img
+	apatchNote
+}
+
+function main(){
+
+cd /dev/tmp/install
+
+chmod a+x ./assets/kpimg
+chmod a+x ./lib/arm64-v8a/libkptools.so
+chmod a+x ./lib/arm64-v8a/libmagiskboot.so
+
+slot=$(getprop ro.boot.slot_suffix)
+
+if [[ ! "$slot" == "" ]]; then
+
+	ui_print ""
+	ui_print "- You are using A/B device."
+
+	# Get kernel
+	ui_print ""
+	dd if=/dev/block/by-name/boot$slot of=/dev/tmp/install/boot.img
+	if [[ "$?" == 0 ]]; then
+		ui_print "- Detected boot partition."
+		boot_execute_ab
+	fi
+
+else
+
+	ui_print "You are using A Only device."
+
+	# Get kernel
+	ui_print ""
+	dd if=/dev/block/by-name/boot of=/dev/tmp/install/boot.img
+	if [[ "$?" == 0 ]]; then
+		ui_print "- Detected boot partition."
+		boot_execute
+	fi
+
+fi
+
+}
+
+main

--- a/scripts/UninstallAP.sh
+++ b/scripts/UninstallAP.sh
@@ -1,0 +1,89 @@
+#!/sbin/bash
+# By SakuraKyuo
+
+OUTFD=/proc/self/fd/$2
+
+function ui_print() {
+  echo -e "ui_print $1\nui_print" >> $OUTFD
+}
+
+function ui_printfile() {
+  while IFS='' read -r line || $BB [[ -n "$line" ]]; do
+    ui_print "$line";
+  done < $1;
+}
+
+function apatchNote(){
+	ui_print "- APatch Unpatch Done"
+	exit
+}
+
+function failed(){
+	ui_print "- APatch Unpatch Failed."
+	ui_print "- Please feedback to the developer with the screenshots."
+	exit
+}
+
+function boot_execute_ab(){
+	./lib/arm64-v8a/libmagiskboot.so unpack boot.img
+	mv kernel kernel-origin
+	./lib/arm64-v8a/libkptools.so -u --image kernel-origin  --out ./kernel
+	if [[ ! "$?" == 0 ]]; then
+		failed
+	fi
+	./lib/arm64-v8a/libmagiskboot.so repack boot.img
+	dd if=/dev/tmp/install/new-boot.img of=/dev/block/by-name/boot$slot
+	apatchNote
+}
+
+function boot_execute(){
+	./lib/arm64-v8a/libmagiskboot.so unpack boot.img
+	mv kernel kernel-origin
+	./lib/arm64-v8a/libkptools.so -u --image kernel-origin  --out ./kernel
+	if [[ ! "$?" == 0 ]]; then
+		failed
+	fi
+	./lib/arm64-v8a/libmagiskboot.so repack boot.img
+	dd if=/dev/tmp/install/new-boot.img of=/dev/block/by-name/boot
+	apatchNote
+}
+
+function main(){
+
+cd /dev/tmp/install
+
+chmod a+x ./lib/arm64-v8a/libkptools.so
+chmod a+x ./lib/arm64-v8a/libmagiskboot.so
+
+slot=$(getprop ro.boot.slot_suffix)
+
+if [[ ! "$slot" == "" ]]; then
+
+	ui_print ""
+	ui_print "- You are using A/B device."
+
+	# Get kernel
+	ui_print ""
+	dd if=/dev/block/by-name/boot$slot of=/dev/tmp/install/boot.img
+	if [[ "$?" == 0 ]]; then
+		ui_print "- Detected boot partition."
+		boot_execute_ab
+	fi
+
+else
+
+	ui_print "You are using A Only device."
+
+	# Get kernel
+	ui_print ""
+	dd if=/dev/block/by-name/boot of=/dev/tmp/install/boot.img
+	if [[ "$?" == 0 ]]; then
+		ui_print "- Detected boot partition."
+		boot_execute
+	fi
+
+fi
+
+}
+
+main

--- a/scripts/update_binary.sh
+++ b/scripts/update_binary.sh
@@ -1,28 +1,13 @@
 #!/sbin/sh
-#
+
 TMPDIR=/dev/tmp
-TD=$2
 rm -rf $TMPDIR
 mkdir -p $TMPDIR 2>/dev/null
 
-ui_print() {
-  echo -n -e "ui_print $1\n" > /proc/self/fd/$TD
-  echo -n -e "ui_print\n" > /proc/self/fd/$TD
-}
-
-ui_print "- Welcome to Apatch twrp tool"
-ui_print "- Installing Apatch from TWRP"
-ui_print "- Powered by Apatch"
-solt=$(getprop ro.boot.slot_suffix)
-if [ -d solt ]; then
-	ui_print "*********************************************************"
-    ui_print "! Your slot is not set, maybe your device does not support A/B"
-    ui_print "! Please backup your device"
-	ui_print "*********************************************************"
-fi
-
 export BBBIN=$TMPDIR/busybox
-for arch in "x86_64" "x86" "arm64-v8a" "armeabi-v7a"; do
+unzip -o "$3" "busybox" -d $TMPDIR >&2
+
+for arch in  "arm64-v8a" ; do
   unzip -o "$3" "lib/$arch/libbusybox.so" -d $TMPDIR >&2
   libpath="$TMPDIR/lib/$arch/libbusybox.so"
   chmod 755 $libpath
@@ -32,13 +17,9 @@ for arch in "x86_64" "x86" "arm64-v8a" "armeabi-v7a"; do
   fi
 done
 $BBBIN rm -rf $TMPDIR/lib
+
 export INSTALLER=$TMPDIR/install
 $BBBIN mkdir -p $INSTALLER
-$BBBIN unzip -o "$3" "assets/*" "lib/*" "META-INF/com/google/*" -x "lib/*/libbusybox.so" -d $INSTALLER >&2
-
+$BBBIN unzip -o "$3" "assets/*" "addon/*" "META-INF/com/google/*" "lib/*" "META-INF/com/google/*" -x "lib/*/libbusybox.so" -d $INSTALLER >&2
 export ASH_STANDALONE=1
-if echo "$3" | $BBBIN grep -q "uninstall"; then
-  exec $BBBIN sh "$INSTALLER/assets/uninstaller.sh" "$@"
-else
-  exec $BBBIN sh "$INSTALLER/META-INF/com/google/android/updater-script" "$@"
-fi
+exec $BBBIN sh "$INSTALLER/META-INF/com/google/android/updater-script" "$@"

--- a/scripts/update_binary.sh
+++ b/scripts/update_binary.sh
@@ -22,4 +22,10 @@ export INSTALLER=$TMPDIR/install
 $BBBIN mkdir -p $INSTALLER
 $BBBIN unzip -o "$3" "assets/*" "addon/*" "META-INF/com/google/*" "lib/*" "META-INF/com/google/*" -x "lib/*/libbusybox.so" -d $INSTALLER >&2
 export ASH_STANDALONE=1
-exec $BBBIN sh "$INSTALLER/META-INF/com/google/android/updater-script" "$@"
+if echo "$3" | $BBBIN grep -q "uninstall"; then
+  exec $BBBIN sh "$INSTALLER/addon/UninstallAP.sh" "$@"
+elif echo "$3" | $BBBIN grep -q "uninstaller"; then
+  exec $BBBIN sh "$INSTALLER/addon/UninstallAP.sh" "$@"
+else
+  exec $BBBIN sh "$INSTALLER/META-INF/com/google/android/updater-script" "$@"
+fi

--- a/scripts/update_script.sh
+++ b/scripts/update_script.sh
@@ -1,120 +1,15 @@
-#Apatch
-############################################
-# Apatch Flash Script (updater-script)
-############################################
+######################
+# APatch Installer #
+######################
 
-##############
-# Preparation
-##############
+OUTFD=/proc/self/fd/$2
 
-# Default permissions
-umask 022
+ui_print() {
+  echo -e "ui_print $1\nui_print" >> $OUTFD
+}
 
-OUTFD=$2
-COMMONDIR=$INSTALLER/assets
-CHROMEDIR=$INSTALLER/assets/chromeos
+cd $INSTALLER
 
-if [ ! -f $COMMONDIR/util_functions.sh ]; then
-  echo "! Unable to extract zip file!"
-  exit 1
-fi
+/sbin/bash "addon/InstallAP.sh" "$OUTFD"
 
-# Load utility functions
-. $COMMONDIR/util_functions.sh
-
-setup_flashable
-
-############
-# Detection
-############
-
-if echo $APATCH_VER | grep -q '\.'; then
-  PRETTY_VER=$APATCH_VER
-else
-  PRETTY_VER="$APATCH_VER($APATCH_VER_CODE)"
-fi
-print_title "APATCH $PRETTY_VER Installer"
-
-is_mounted /data || mount /data || is_mounted /cache || mount /cache
-mount_partitions
-check_data
-get_flags
-find_boot_image
-
-[ -z $BOOTIMAGE ] && abort "! Unable to detect target image"
-ui_print "- Target image: $BOOTIMAGE"
-
-# Detect version and architecture
-api_level_arch_detect
-
-[ $API -lt 23 ] && abort "! APATCH only supports Android 6.0 and above"
-
-ui_print "- Device platform: $ABI"
-
-BINDIR=$INSTALLER/lib/$ABI
-cd $BINDIR
-for file in lib*.so; do mv "$file" "${file:3:${#file}-6}"; done
-cd /
-
-#cp -af $INSTALLER/lib/$ABI32/libmagisk32.so $BINDIR/magisk32 2>/dev/null
-
-# Check if system root is installed and remove
-$BOOTMODE || remove_system_su
-
-##############
-# Environment
-##############
-chmod 755 libmagiskboot.so
-chmod 755 libkptools.so
-solt=$(getprop ro.boot.slot_suffix)
-dd if=/dev/block/by-name/boot$solt of=boot.img
-mv kernel kernel-b
-libmagiskboot.so unpack boot.img
-set -x
-libkptools.so -p -i kernel-b -K libkpatch.so -s a1234567 -k kpimg -o kernel
-patch_rc=$?
-set +x
-if [ $patch_rc -ne 0 ]; then
-  ui_print "- Patch kernel error: $patch_rc"
-  exit $?
-fi
-libmagiskboot.so repack boot.img
-dd if=boot.img of=/dev/block/by-name/boot$solt
-
-exit 1
-
-ui_print "- Constructing environment"
-
-# Copy required files
-rm -rf $MAGISKBIN/* 2>/dev/null
-mkdir -p $MAGISKBIN 2>/dev/null
-cp -af $BINDIR/. $COMMONDIR/. $BBBIN $MAGISKBIN
-
-# Remove files only used by the Magisk app
-rm -f $MAGISKBIN/bootctl $MAGISKBIN/main.jar \
-  $MAGISKBIN/module_installer.sh $MAGISKBIN/uninstaller.sh
-
-chmod -R 755 $MAGISKBIN
-
-# addon.d
-if [ -d /system/addon.d ]; then
-  ui_print "- Adding addon.d survival script"
-  blockdev --setrw /dev/block/mapper/system$SLOT 2>/dev/null
-  mount -o rw,remount /system || mount -o rw,remount /
-  ADDOND=/system/addon.d/99-magisk.sh
-  cp -af $COMMONDIR/addon.d.sh $ADDOND
-  chmod 755 $ADDOND
-fi
-
-##################
-# Image Patching
-##################
-
-install_apatch
-
-# Cleanups
-$BOOTMODE || recovery_cleanup
-rm -rf $TMPDIR
-
-ui_print "- Done"
 exit 0


### PR DESCRIPTION
Add flash script into APatch Manager, with that, users can more easier to get APatch like how they get Magisk.

It's default key is apatch66

We have reverted some codes which have removed in https://github.com/bmax121/APatch/commit/8c5c34e35d9836aa8aaebff6bcab9b3588868ea2, without them, we can't include flash script into Manager.

We have deleted outdated flash script in assest folder(https://github.com/bmax121/APatch/commit/7e81c81d9dd417354d124eff22a25c42265e1c44), we don't need it for now.

Test: Build Manager - Flash in Third-Party Recovery - Reboot - Enter default key - Check APatch

Result: It works well(Tested on Oneplus Ace 3 Pro)

Needs to improve:
- Need to add Kernel Flags detecte