### PR TITLE
script: Support flash APatch in AOSP Based Recovery

### DIFF
--- a/scripts/InstallAP.sh
+++ b/scripts/InstallAP.sh
@@ -1,7 +1,7 @@
-#!/sbin/bash
+#!/bin/sh
 # By SakuraKyuo
 
-OUTFD=$1
+OUTFD=/proc/self/fd/$2
 
 function ui_print() {
   echo -e "ui_print $1\nui_print" >> $OUTFD
@@ -31,7 +31,6 @@ function failed(){
 function boot_execute_ab(){
 	./lib/arm64-v8a/libmagiskboot.so unpack boot.img
 	mv kernel kernel-origin
-	# ./lib/arm64-v8a/libkptools.so boot-patch -b boot.img --magiskboot ./lib/arm64-v8a/libmagiskboot.so >> /dev/tmp/install/log
 	./lib/arm64-v8a/libkptools.so -p --image kernel-origin --skey "$skey" --kpimg ./assets/kpimg --out ./kernel >> /dev/tmp/install/log
 	if [[ ! "$?" == 0 ]]; then
 		failed
@@ -46,7 +45,6 @@ function boot_execute_ab(){
 function boot_execute(){
 	./lib/arm64-v8a/libmagiskboot.so unpack boot.img
 	mv kernel kernel-origin
-	# ./lib/arm64-v8a/libkptools.so boot-patch -b boot.img --magiskboot ./lib/arm64-v8a/libmagiskboot.so >> /dev/tmp/install/log
 	./lib/arm64-v8a/libkptools.so -p --image kernel-origin --skey "$skey" --kpimg ./assets/kpimg --out ./kernel >> /dev/tmp/install/log
 	if [[ ! "$?" == 0 ]]; then
 		failed

--- a/scripts/UninstallAP.sh
+++ b/scripts/UninstallAP.sh
@@ -1,4 +1,4 @@
-#!/sbin/bash
+#!/bin/sh
 # By SakuraKyuo
 
 OUTFD=/proc/self/fd/$2

--- a/scripts/update_binary.sh
+++ b/scripts/update_binary.sh
@@ -1,4 +1,4 @@
-#!/sbin/sh
+#!/bin/sh
 
 TMPDIR=/dev/tmp
 rm -rf $TMPDIR
@@ -27,5 +27,5 @@ if echo "$3" | $BBBIN grep -q "uninstall"; then
 elif echo "$3" | $BBBIN grep -q "uninstaller"; then
   exec $BBBIN sh "$INSTALLER/addon/UninstallAP.sh" "$@"
 else
-  exec $BBBIN sh "$INSTALLER/META-INF/com/google/android/updater-script" "$@"
+  exec $BBBIN sh "$INSTALLER/addon/InstallAP.sh" "$@"
 fi

--- a/scripts/update_script.sh
+++ b/scripts/update_script.sh
@@ -1,15 +1,5 @@
 ######################
-# APatch Installer #
+# APatch Empty script
+# Check update-binary
 ######################
 
-OUTFD=/proc/self/fd/$2
-
-ui_print() {
-  echo -e "ui_print $1\nui_print" >> $OUTFD
-}
-
-cd $INSTALLER
-
-/sbin/bash "addon/InstallAP.sh" "$OUTFD"
-
-exit 0


### PR DESCRIPTION
After Android 11, the AOSP-based Recovery no longer has /sbin, while TWRP and LineageOS-based Recovery retain the /sbin/sh interpreter to provide compatibility with this shell flashing script. TWRP also adds bash to /sbin.

In order to adapt to AOSP-Based Recovery, we canceled the use of /sbin/bash to run the installation script, and instead used APatch's built-in busybox to run the installation script to achieve the purpose of adapting to all recovery.

We don't need updater-script anymore, so keep it empty. The core part is in update-binary and addon folder.

Test: Build Manager - Flash in AOSP-Based Recovery - Reboot - Enter the key - Check APatch

Result: It works on AOSP-Based & LineageOS-Based Recovery now, TWRP also works well(Tested on Xiaomi MI MIX & Oneplus Ace 3 Pro)