### PR TITLE
scripts: kernel configuration detection script bug fix

### DIFF
--- a/scripts/extract-ikconfig
+++ b/scripts/extract-ikconfig
@@ -38,8 +38,8 @@ then
 fi
 
 # Prepare temp files:
-tmp1=$(mktemp -t ikconfig.XXXXXX)
-tmp2=$(mktemp -t ikconfig.XXXXXX)
+tmp1=$(toybox mktemp -t ikconfig.XXXXXX)
+tmp2=$(toybox mktemp -t ikconfig.XXXXXX)
 trap "rm -f $tmp1 $tmp2" 0
 
 # Initial attempt for uncompressed images or objects:


### PR DESCRIPTION
With tests, mktemp won't provided in some Recovery then it will abort because of the incorrect kernel configuration detection result. We have use mktemp provided by toybox to avoid this issue.

Test: Build Manager - Flash in Recovery - Check result

Result: It can work on some recovery which not provide mktemp