### PR TITLE
scripts: Fixed detecting kernel configuration in APP

### DIFF
--- a/app/src/main/assets/boot_patch.sh
+++ b/app/src/main/assets/boot_patch.sh
@@ -49,7 +49,7 @@ echo "- Unpacking boot image"
   fi
 fi
 
-if [ ! $(sh extract-ikconfig kernel | grep CONFIG_KALLSYMS=y) ]; then
+if [ ! $(sh extract-ikconfig kernel "/data/user/0/me.bmax.apatch/cache/" | grep CONFIG_KALLSYMS=y) ]; then
 	echo "- Patcher has Aborted!"
 	echo "- APatch requires CONFIG_KALLSYMS to be Enabled."
 	echo "- But your kernel seems NOT enabled it."

--- a/app/src/main/assets/extract-ikconfig
+++ b/app/src/main/assets/extract-ikconfig
@@ -31,15 +31,17 @@ dump_config()
 # Check invocation:
 me=${0##*/}
 img=$1
-if	[ $# -ne 1 -o ! -s "$img" ]
-then
-	echo "Usage: $me <kernel-image>" >&2
-	exit 2
-fi
+path=$2
 
 # Prepare temp files:
-tmp1=$(toybox mktemp -t ikconfig.XXXXXX)
-tmp2=$(toybox mktemp -t ikconfig.XXXXXX)
+if [ $# -ne 2 ]
+then
+	tmp1=$(toybox mktemp -t ikconfig.XXXXXX)
+	tmp2=$(toybox mktemp -t ikconfig.XXXXXX)
+else
+	tmp1=$(toybox mktemp -p $2)
+	tmp2=$(toybox mktemp -p $2)
+fi
 trap "rm -f $tmp1 $tmp2" 0
 
 # Initial attempt for uncompressed images or objects:


### PR DESCRIPTION
In commit https://github.com/bmax121/APatch/commit/6d62eaebcf6fdfa08253da2386d2b17557bbce24, we used mktemp provided by toybox to avoid the problem of missing mktemp. However, the test found that permission denied would occur on some devices because mktemp provided by toybox would create temporary files in /tmp, which is not possible in non-Recovery. Therefore, we added the parameter of passing in the APP cache directory to the APP patch script as the directory for mktemp to generate temporary files. This parameter is not passed in when flashing in Recovery mode.

Test: Build Manager - Patch in the device that not have mktemp - Check result

Result: It's working fine now(Tested on Redmi Note 11 5G)