### PR TITLE
Manager: Add SuperKey special character detection

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/PatchesViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/PatchesViewModel.kt
@@ -34,6 +34,7 @@ import org.ini4j.Ini
 import java.io.File
 import java.io.IOException
 import java.io.StringReader
+import java.util.regex.Pattern
 
 private const val TAG = "PatchViewModel"
 
@@ -354,6 +355,17 @@ class PatchesViewModel : ViewModel() {
                     Log.d(TAG, "" + e)
                     patchLog += "\n"
                 }
+            }
+
+            val specialCharactersPattern = Pattern.compile("[$\"\'\\[\\]]")
+
+            if (specialCharactersPattern.matcher(superkey).find()) {
+                val msg = " SuperKey contains special characters: \$\" \'[]"
+                error = msg
+                patching = false
+                return@launch
+            } else {
+                error = ""
             }
             logs.add("****************************")
 


### PR DESCRIPTION
When patching in APP, users usually use special characters as SuperKey for security reasons. However, since users often use special characters that may cause program errors as SuperKey, special character detection is added.

While ensuring that most special characters can still be used as SuperKey normally, the special character detection added this time only includes `$ " ' [ ]`, which are special symbols that are easy to cause program errors. Other special symbols such as `@ #` are not affected.

Test: Build Manager - Patch kernel with using special character that not allow - Patch won't start and throw error note