### PR TITLE
scripts: Completely fix kernel configuration detection

### DIFF
--- a/app/src/main/assets/InstallAP.sh
+++ b/app/src/main/assets/InstallAP.sh
@@ -37,7 +37,7 @@ function failed(){
 
 function boot_execute_ab(){
 	./lib/arm64-v8a/libmagiskboot.so unpack boot.img
-	if [[ ! "$(./assets/extract-ikconfig ./kernel | grep CONFIG_KALLSYMS= | cut -d = -f 2)" == "y" ]]; then
+	if [[ ! $(sh assets/extract-ikconfig ./kernel | grep CONFIG_KALLSYMS=y) ]]; then
 		kernelFlagsErr
 	fi
 	mv kernel kernel-origin
@@ -54,7 +54,7 @@ function boot_execute_ab(){
 
 function boot_execute(){
 	./lib/arm64-v8a/libmagiskboot.so unpack boot.img
-	if [[ ! "$(./assets/extract-ikconfig ./kernel | grep CONFIG_KALLSYMS= | cut -d = -f 2)" == "y" ]]; then
+	if [[ ! $(sh assets/extract-ikconfig ./kernel | grep CONFIG_KALLSYMS=y) ]]; then
 		kernelFlagsErr
 	fi
 	mv kernel kernel-origin

--- a/app/src/main/assets/boot_patch.sh
+++ b/app/src/main/assets/boot_patch.sh
@@ -49,7 +49,7 @@ echo "- Unpacking boot image"
   fi
 fi
 
-if [ ! $(sh extract-ikconfig kernel "/data/user/0/me.bmax.apatch/cache/" | grep CONFIG_KALLSYMS=y) ]; then
+if [ ! $(sh extract-ikconfig kernel | grep CONFIG_KALLSYMS=y) ]; then
 	echo "- Patcher has Aborted!"
 	echo "- APatch requires CONFIG_KALLSYMS to be Enabled."
 	echo "- But your kernel seems NOT enabled it."

--- a/app/src/main/assets/extract-ikconfig
+++ b/app/src/main/assets/extract-ikconfig
@@ -1,52 +1,26 @@
 #!/bin/sh
-# ----------------------------------------------------------------------
-# extract-ikconfig - Extract the .config file from a kernel image
+# ref: kernel/configs.c: .rodata ( ... IKCFG_ST.........................IKCFG_ED ... )
+#                                              ^ kernel/config_data.gz ^
+#      scripts/extract-ikconfig
 #
-# This will only work when the kernel was compiled with CONFIG_IKCONFIG.
-#
-# The obscure use of the "tr" filter is to work around older versions of
-# "grep" that report the byte offset of the line instead of the pattern.
-#
-# (c) 2009,2010 Dick Streefland <dick@streefland.net>
-# Licensed under the terms of the GNU General Public License.
-# ----------------------------------------------------------------------
 
-cf1='IKCFG_ST\037\213\010'
-cf2='0123456789'
-
-dump_config()
-{
-	if	pos=`tr "$cf1\n$cf2" "\n$cf2=" < "$1" | toybox grep -abo "^$cf2"`
-	then
-		pos=${pos%%:*}
-		tail -c+$(($pos+8)) "$1" | zcat > $tmp1 2> /dev/null
-		if	[ $? != 1 ]
-		then	# exit status must be 0 or 2 (trailing garbage warning)
-			cat $tmp1
-			exit 0
-		fi
-	fi
-}
-
-# Check invocation:
 me=${0##*/}
 img=$1
-path=$2
-
-# Prepare temp files:
-if [ $# -ne 2 ]
-then
-	tmp1=$(toybox mktemp -t ikconfig.XXXXXX)
-	tmp2=$(toybox mktemp -t ikconfig.XXXXXX)
-else
-	tmp1=$(toybox mktemp -p $2)
-	tmp2=$(toybox mktemp -p $2)
+if [ $# -ne 1 -o ! -s "$img" ]; then
+  echo "Usage: $me <kernel-image>" >&2
+  exit 2
 fi
-trap "rm -f $tmp1 $tmp2" 0
 
-# Initial attempt for uncompressed images or objects:
-dump_config "$img"
+pos=$(toybox grep -abo "IKCFG_ST" $img)
+[ $? -ne 0 ] && echo "$me: Cannot find kernel config." >&2 && exit 1
 
-# Bail out:
-echo "$me: Cannot find kernel config." >&2
-exit 1
+pos=${pos%%:*}
+kcfg_start=$(($pos+8))
+
+pos=$(toybox grep -abo "IKCFG_ED" $img)
+pos=${pos%%:*}
+kcfg_end=$(($pos-1))
+
+kcfg_bytes=$(($kcfg_end-$kcfg_start+1))
+
+dd if=$img bs=1 skip=$kcfg_start count=$kcfg_bytes status=none | zcat


### PR DESCRIPTION
In previous commits https://github.com/bmax121/APatch/commit/6d62eaebcf6fdfa08253da2386d2b17557bbce24 and https://github.com/bmax121/APatch/commit/38649e07e156ff00b8b396f781b284db20300134, we tried to fix the kernel configuration detection error when patching kernel via app or flashing in recovery, but after a lot of testing, we still found that it does not work properly in some extreme cases, such as when the user changes the APP package name.

In response to this, this commit updates the extract-ikconfig script to use a newer implementation to detect kernel configuration and does not use the mktemp command, which means that the problem of mktemp not existing in some systems and recovery will no longer occur. At the same time, since there is no need to use mktemp to create temporary files, there will be no problem like Commit https://github.com/bmax121/APatch/commit/38649e07e156ff00b8b396f781b284db20300134 where the user cannot use the software package normally after changing the name.

Test: Build Manager - Changes the APP package name -  Patch kernel via app - Kernel Configuration detection working

Result: Working in most of devices