### PR TITLE
Manager: Add SuperKey special character detection

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/Patches.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Patches.kt
@@ -370,6 +370,7 @@ private fun ExtraItem(extra: KPModel.IExtraInfo, existed: Boolean, onDelete: () 
 private fun SetSuperKeyView(viewModel: PatchesViewModel) {
     var skey by remember { mutableStateOf(viewModel.superkey) }
     var showWarn by remember { mutableStateOf(!viewModel.checkSuperKeyValidation(skey)) }
+    var charactersWarn by remember { mutableStateOf(!viewModel.checkSuperKeyCharacters(skey)) }
     var keyVisible by remember { mutableStateOf(false) }
     ElevatedCard(
         colors = CardDefaults.elevatedCardColors(containerColor = run {
@@ -399,6 +400,14 @@ private fun SetSuperKeyView(viewModel: PatchesViewModel) {
                     style = MaterialTheme.typography.bodyMedium
                 )
             }
+            if (charactersWarn) {
+                Spacer(modifier = Modifier.height(3.dp))
+                Text(
+                    color = Color.Red,
+                    text = stringResource(id = R.string.patch_item_set_skey_invalid_label),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
             Column {
                 //Spacer(modifier = Modifier.height(8.dp))
                 Box(
@@ -421,6 +430,14 @@ private fun SetSuperKeyView(viewModel: PatchesViewModel) {
                             } else {
                                 viewModel.superkey = ""
                                 showWarn = true
+                            }
+
+                            if (viewModel.checkSuperKeyCharacters(it)) {
+                                viewModel.superkey = it
+                                charactersWarn = false
+                            } else {
+                                viewModel.superkey = ""
+                                charactersWarn = true
                             }
                         },
                     )

--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/PatchesViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/PatchesViewModel.kt
@@ -144,6 +144,9 @@ class PatchesViewModel : ViewModel() {
                 if (checkSuperKeyValidation(superkey)) {
                     this.superkey = superkey
                 }
+                if (checkSuperKeyCharacters(superkey)) {
+                    this.superkey = superkey
+                }
                 var kpmNum = kernel["extra_num"]?.toInt()
                 if (kpmNum == null) {
                     val extras = ini["extras"]
@@ -184,6 +187,10 @@ class PatchesViewModel : ViewModel() {
 
     val checkSuperKeyValidation: (superKey: String) -> Boolean = { superKey ->
         superKey.length in 8..63 && superKey.any { it.isDigit() } && superKey.any { it.isLetter() }
+    }
+
+    val checkSuperKeyCharacters: (superKey: String) -> Boolean = { superKey ->
+        superKey.none { it in "$\"'[]`" }
     }
 
     fun copyAndParseBootimg(uri: Uri) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <string name="patch_item_extra_event">Event:</string>
     <string name="patch_item_skey">Super Key</string>
     <string name="patch_item_set_skey_label">The length of super key should be at least 8 characters and include both numbers and letters</string>
+    <string name="patch_item_set_skey_invalid_label">Super key contains special characters: $ \" \' \[ \] \`</string>
 
 
     <string name="home_kernel">Kernel</string>


### PR DESCRIPTION
When patching in APP, users usually use special characters as SuperKey for security reasons. However, since users often use special characters that may cause program errors as SuperKey, special character detection is added.

While ensuring that most special characters can still be used as SuperKey normally, the special character detection added this time only includes $ " ' [ ], which are special symbols that are easy to cause program errors. Other special symbols such as @ # are not affected.

Test: Build Manager - Patch kernel with using special character that not allow - Patch won't start and throw error note