### PR TITLE
Support all special characters as super key

### DIFF
--- a/app/src/main/assets/boot_patch.sh
+++ b/app/src/main/assets/boot_patch.sh
@@ -28,7 +28,7 @@ echo "****************************"
 echo " APatch Boot Image Patcher"
 echo "****************************"
 
-SUPERKEY=$1
+SUPERKEY="$1"
 BOOTIMAGE=$2
 FLASH_TO_DEVICE=$3
 shift 2

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Patches.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Patches.kt
@@ -370,7 +370,6 @@ private fun ExtraItem(extra: KPModel.IExtraInfo, existed: Boolean, onDelete: () 
 private fun SetSuperKeyView(viewModel: PatchesViewModel) {
     var skey by remember { mutableStateOf(viewModel.superkey) }
     var showWarn by remember { mutableStateOf(!viewModel.checkSuperKeyValidation(skey)) }
-    var charactersWarn by remember { mutableStateOf(!viewModel.checkSuperKeyCharacters(skey)) }
     var keyVisible by remember { mutableStateOf(false) }
     ElevatedCard(
         colors = CardDefaults.elevatedCardColors(containerColor = run {
@@ -400,14 +399,6 @@ private fun SetSuperKeyView(viewModel: PatchesViewModel) {
                     style = MaterialTheme.typography.bodyMedium
                 )
             }
-            if (charactersWarn) {
-                Spacer(modifier = Modifier.height(3.dp))
-                Text(
-                    color = Color.Red,
-                    text = stringResource(id = R.string.patch_item_set_skey_invalid_label),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            }
             Column {
                 //Spacer(modifier = Modifier.height(8.dp))
                 Box(
@@ -430,14 +421,6 @@ private fun SetSuperKeyView(viewModel: PatchesViewModel) {
                             } else {
                                 viewModel.superkey = ""
                                 showWarn = true
-                            }
-
-                            if (viewModel.checkSuperKeyCharacters(it)) {
-                                viewModel.superkey = it
-                                charactersWarn = false
-                            } else {
-                                viewModel.superkey = ""
-                                charactersWarn = true
                             }
                         },
                     )

--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/PatchesViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/PatchesViewModel.kt
@@ -144,9 +144,6 @@ class PatchesViewModel : ViewModel() {
                 if (checkSuperKeyValidation(superkey)) {
                     this.superkey = superkey
                 }
-                if (checkSuperKeyCharacters(superkey)) {
-                    this.superkey = superkey
-                }
                 var kpmNum = kernel["extra_num"]?.toInt()
                 if (kpmNum == null) {
                     val extras = ini["extras"]
@@ -187,10 +184,6 @@ class PatchesViewModel : ViewModel() {
 
     val checkSuperKeyValidation: (superKey: String) -> Boolean = { superKey ->
         superKey.length in 8..63 && superKey.any { it.isDigit() } && superKey.any { it.isLetter() }
-    }
-
-    val checkSuperKeyCharacters: (superKey: String) -> Boolean = { superKey ->
-        superKey.none { it in "$\"'[]`" }
     }
 
     fun copyAndParseBootimg(uri: Uri) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,6 @@
     <string name="patch_item_extra_event">Event:</string>
     <string name="patch_item_skey">Super Key</string>
     <string name="patch_item_set_skey_label">The length of super key should be at least 8 characters and include both numbers and letters</string>
-    <string name="patch_item_set_skey_invalid_label">Super key contains special characters: $ \" \' \[ \] \`</string>
 
 
     <string name="home_kernel">Kernel</string>


### PR DESCRIPTION
In commit https://github.com/bmax121/APatch/commit/93154859b69e588f413adff397a80e7c45598987, we did not allow some special characters to be set as SuperKey because they would cause the program error. Now I have fixed the issue that using special characters as SuperKey would cause program errors, so I have also reverted that commit.

Before this PR, the manager won't use array concatenation when running patch scripts. Some special characters, such as $ " ' [ ] `, would cause unexpected behavior, resulting in runtime errors. But now we use array concatenation when running patch scripts, so it will not cause errors. Users can use all special characters as SuperKey, which improves security.

Test: Build manager - patch kernel with special characters - now works fine