### PR TITLE
script: Add kernel configuration CONFIG_KALLSYMS_ALL detection

### DIFF
--- a/app/src/main/assets/boot_patch.sh
+++ b/app/src/main/assets/boot_patch.sh
@@ -73,6 +73,12 @@ fi
 echo "- Repacking boot image"
 ./magiskboot repack "$BOOTIMAGE" >/dev/null 2>&1
 
+if [ ! $(sh extract-ikconfig kernel.ori | grep CONFIG_KALLSYMS_ALL=y) ]; then
+	echo "- Detected CONFIG_KALLSYMS_ALL is not set!"
+	echo "- APatch has patched but maybe your device won't boot."
+	echo "- Make sure you have original boot image backup."
+fi
+
 if [ $? -ne 0 ]; then
   >&2 echo "- Repack error: $?"
   exit $?


### PR DESCRIPTION
After patching is complete, check if the kernel configuration CONFIG_KALLSYMS_ALL is set, otherwise warn the user that kernel configuration is not set and bootloop may occur.