### PR TITLE
Add magiskboot to bin folder

### DIFF
--- a/apd/src/assets.rs
+++ b/apd/src/assets.rs
@@ -6,10 +6,12 @@ use crate::{defs::BINARY_DIR, utils};
 pub const RESETPROP_PATH: &str = concatcp!(BINARY_DIR, "resetprop");
 pub const BUSYBOX_PATH: &str = concatcp!(BINARY_DIR, "busybox");
 pub const MAGISKPOLICY_PATH: &str = concatcp!(BINARY_DIR, "magiskpolicy");
+pub const MAGISKBOOT_PATH: &str = concatcp!(BINARY_DIR, "magiskboot");
 
 pub fn ensure_binaries() -> Result<()> {
     utils::ensure_binary(RESETPROP_PATH)?;
     utils::ensure_binary(BUSYBOX_PATH)?;
     utils::ensure_binary(MAGISKPOLICY_PATH)?;
+    utils::ensure_binary(MAGISKBOOT_PATH)?;
     Ok(())
 }

--- a/app/src/main/java/me/bmax/apatch/APatchApp.kt
+++ b/app/src/main/java/me/bmax/apatch/APatchApp.kt
@@ -54,6 +54,7 @@ class APApplication : Application() {
         private const val MAGISKPOLICY_BIN_PATH = APATCH_BIN_FOLDER + "magiskpolicy"
         private const val BUSYBOX_BIN_PATH = APATCH_BIN_FOLDER + "busybox"
         private const val RESETPROP_BIN_PATH = APATCH_BIN_FOLDER + "resetprop"
+        private const val MAGISKBOOT_BIN_PATH = APATCH_BIN_FOLDER + "magiskboot"
         const val MAGISK_SCONTEXT = "u:r:magisk:s0"
 
         private const val DEFAULT_SU_PATH = "/system/bin/kp"
@@ -127,6 +128,8 @@ class APApplication : Application() {
                 "chmod +x $RESETPROP_BIN_PATH",
                 "cp -f ${nativeDir}/libbusybox.so $BUSYBOX_BIN_PATH",
                 "chmod +x $BUSYBOX_BIN_PATH",
+                "cp -f ${nativeDir}/libmagiskboot.so $MAGISKBOOT_BIN_PATH",
+                "chmod +x $MAGISKBOOT_BIN_PATH",
 
                 "touch $PACKAGE_CONFIG_FILE",
                 "touch $SU_PATH_FILE",


### PR DESCRIPTION
Some modules expect magiskboot to be available in PATH. Add binary to ap/bin folder so it is available in PATH