### PR TITLE
Not clobber root permission when trying to change exclude status.

### DIFF
--- a/apd/src/supercall.rs
+++ b/apd/src/supercall.rs
@@ -282,7 +282,7 @@ pub fn refresh_ap_package_list(skey: &CStr, mutex: &Arc<Mutex<()>>) {
 
     let package_configs = read_ap_package_config();
     for config in package_configs {
-        if config.allow == 1 && config.exclude == 0 {
+        if config.allow == 1 {
             let profile = SuProfile {
                 uid: config.uid,
                 to_uid: config.to_uid,
@@ -294,7 +294,7 @@ pub fn refresh_ap_package_list(skey: &CStr, mutex: &Arc<Mutex<()>>) {
                 config.pkg, result
             );
         }
-        if config.allow == 0 && config.exclude == 1 {
+        if config.exclude == 1 {
             let result = sc_set_ap_mod_exclude(skey, config.uid as i64, 1);
             info!(
                 "[refresh_ap_package_list] Loading exclude {}: result = {}",

--- a/app/src/main/java/me/bmax/apatch/ui/screen/SuperUser.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/SuperUser.kt
@@ -147,14 +147,7 @@ private fun AppItem(
 
     ListItem(
         modifier = Modifier.clickable(onClick = {
-            if (!rootGranted) {
-                showEditProfile = !showEditProfile
-            } else {
-                rootGranted = false
-                config.allow = 0
-                Natives.revokeSu(app.uid)
-                PkgConfig.changeConfig(config)
-            }
+            showEditProfile = !showEditProfile
         }),
         headlineContent = { Text(app.label) },
         leadingContent = {
@@ -212,7 +205,7 @@ private fun AppItem(
             })
         },
     )
-    if (showEditProfile && !rootGranted) {
+    if (showEditProfile) {
         //var viahook by remember { mutableStateOf(app.config.profile.scontext.isEmpty()) }
 
         Column(modifier = Modifier.padding(start = 24.dp, end = 24.dp)) {
@@ -236,8 +229,6 @@ private fun AppItem(
                 onCheckedChange = {
                     if (it) {
                         excludeApp = 1
-                        config.allow = 0
-                        Natives.revokeSu(app.uid)
                     } else {
                         excludeApp = 0
                     }


### PR DESCRIPTION
Currently users cannot toggle the exclusion status without revoking root permissions, which should be independent from each other.  The permission is automatically revoked, they need to grant it again.

The problem is that if the app's selinux context was set to some specific role other than the one of magisk, it got reset, and users need to mannually modify `pacakge_config` file and reboot to make it work.