### PR TITLE
script: Add superkey only number or letter detect

### DIFF
--- a/app/src/main/assets/InstallAP.sh
+++ b/app/src/main/assets/InstallAP.sh
@@ -82,6 +82,16 @@ slot=$(getprop ro.boot.slot_suffix)
 
 skey=$(cat /proc/sys/kernel/random/uuid | cut -d \- -f1)
 
+while true; do
+    if [[ "$skey" =~ ^[0-9]+$ ]]; then
+        skey=$(cat /proc/sys/kernel/random/uuid | cut -d \- -f1)
+    elif [[ "$skey" =~ ^[a-zA-Z]+$ ]]; then
+        skey=$(cat /proc/sys/kernel/random/uuid | cut -d \- -f1)
+    else
+        break
+    fi
+done
+
 if [[ ! "$slot" == "" ]]; then
 
 	ui_print ""


### PR DESCRIPTION
From a security perspective, Apatch does not allow superkey that are only numbers or English. However, in extreme cases, superkey that are only numbers or letters may be generated. Therefore, this commit is for repair