### PR TITLE
APD: Implement 'kpm list' command

### DIFF
--- a/apd/src/cli.rs
+++ b/apd/src/cli.rs
@@ -88,7 +88,7 @@ enum Module {
 enum Kpmsub  {
     /// Load Kernelpath module
     Load {
-        // secret key
+        // super_key
         key: String,
         // kpm module path
         path: String

--- a/apd/src/cli.rs
+++ b/apd/src/cli.rs
@@ -6,7 +6,7 @@ use android_logger::Config;
 #[cfg(target_os = "android")]
 use log::LevelFilter;
 
-use crate::{defs, event, module, supercall, utils};
+use crate::{defs, event, kpm, module, supercall, utils};
 use std::ffi::{CString, CStr};
 /// APatch cli
 #[derive(Parser, Debug)]
@@ -88,12 +88,12 @@ enum Module {
 enum Kpmsub  {
     /// Load Kernelpath module
     Load {
-        // super_key
-        key: String,
         // kpm module path
         path: String
     },
 
+    /// List all Kernelpath modules
+    List {},  
 }
 
 pub fn run() -> Result<()> {
@@ -136,17 +136,8 @@ pub fn run() -> Result<()> {
 
         Commands::Kpm { command } => {
             match command {
-                Kpmsub::Load { key,path } => {
-                    let key_cstr = CString::new(key).map_err(|_| anyhow::anyhow!("Invalid key string"))?;
-                    let path_cstr = CString::new(path).map_err(|_| anyhow::anyhow!("Invalid path string"))?;
-                    let ret = supercall::sc_kpm_load(key_cstr.as_c_str(),path_cstr.as_c_str(),None,std::ptr::null_mut());
-                    if ret < 0 {
-                        Err(anyhow::anyhow!("System call failed with error code {}", ret))
-                    } else {
-                        Ok(())
-                    }
-                
-                }
+                Kpmsub::Load { path } => kpm::load_module(cli.superkey, path),
+                Kpmsub::List { } => kpm::list_modules(cli.superkey),
                 _ => Err(anyhow::anyhow!("Unsupported command")),
                 
             }

--- a/apd/src/cli.rs
+++ b/apd/src/cli.rs
@@ -86,7 +86,7 @@ enum Module {
 }
 #[derive(clap::Subcommand, Debug)]
 enum Kpmsub  {
-    /// Load Kernelpath module
+    /// Load KernelPatch module
     Load {
         // super_key
         key: String,
@@ -94,7 +94,7 @@ enum Kpmsub  {
         path: String
     },
 
-    /// List all Kernelpath modules
+    /// List all KernelPatch modules
     List {},  
 }
 

--- a/apd/src/cli.rs
+++ b/apd/src/cli.rs
@@ -88,6 +88,8 @@ enum Module {
 enum Kpmsub  {
     /// Load Kernelpath module
     Load {
+        // secret key
+        key: String,
         // kpm module path
         path: String
     },
@@ -136,7 +138,7 @@ pub fn run() -> Result<()> {
 
         Commands::Kpm { command } => {
             match command {
-                Kpmsub::Load { path } => kpm::load_module(cli.superkey, path),
+                Kpmsub::Load { key, path } => kpm::load_module(key, path),
                 Kpmsub::List { } => kpm::list_modules(cli.superkey),
                 _ => Err(anyhow::anyhow!("Unsupported command")),
                 

--- a/apd/src/kpm.rs
+++ b/apd/src/kpm.rs
@@ -1,0 +1,95 @@
+use std::ffi::{CStr, CString};
+use serde::{Deserialize, Serialize};
+
+use crate::supercall;
+
+#[derive(Serialize, Deserialize)]
+struct ModuleInfo {
+    name: String,
+    version: String,
+    author: String,
+    description: String,
+    args: String,
+    license: String,
+}
+
+
+fn module_info(key_cstr: CString, name: String) -> anyhow::Result<ModuleInfo> {
+    let name_cstr = CString::new(name).map_err(|_| anyhow::anyhow!("Invalid name string"))?;
+    let mut info_buf = vec![0; 4096];
+    let ret = supercall::sc_kpm_info(key_cstr.as_c_str(), name_cstr.as_c_str(), &mut info_buf);
+    if ret < 0 {
+        return Err(anyhow::anyhow!("System call failed with error code {}", ret))
+    }
+
+    let info = CStr::from_bytes_until_nul(&info_buf)
+        .map_err(|_| anyhow::anyhow!("Invalid info buffer"))?
+        .to_str()
+        .map_err(|_| anyhow::anyhow!("Invalid UTF-8 in info buffer"))?;
+
+    let info: ModuleInfo = info
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .fold(ModuleInfo {
+            name: String::new(),
+            version: String::new(), 
+            author: String::new(),
+            description: String::new(),
+            args: String::new(),
+            license: String::new(),
+        }, |mut info, (key, value)| {
+            match key {
+                "name" => info.name = value.to_owned(),
+                "version" => info.version = value.to_owned(),
+                "author" => info.author = value.to_owned(),
+                "description" => info.description = value.to_owned(),
+                "args" => info.args = value.to_owned(),
+                "license" => info.license = value.to_owned(),
+                _ => (),
+            }
+            info
+        });
+
+    return Ok(info)
+}
+
+pub fn load_module(superkey: Option<String>, path: String) -> anyhow::Result<()> {
+    let key_cstr = match superkey {
+        Some(x) => CString::new(x).map_err(|_| anyhow::anyhow!("Invalid key string"))?,
+        None => return Err(anyhow::anyhow!("No superkey provided")),
+    };
+    let path_cstr = CString::new(path).map_err(|_| anyhow::anyhow!("Invalid path string"))?;
+    let ret = supercall::sc_kpm_load(key_cstr.as_c_str(),path_cstr.as_c_str(),None,std::ptr::null_mut());
+    if ret < 0 {
+        return Err(anyhow::anyhow!("System call failed with error code {}", ret))
+    } else {
+        return Ok(())
+    }
+}
+
+pub fn list_modules(superkey: Option<String>) -> anyhow::Result<()> {
+    let key_cstr: CString = match superkey {
+        Some(x) => CString::new(x).map_err(|_| anyhow::anyhow!("Invalid key string"))?,
+        None => return Err(anyhow::anyhow!("No superkey provided")),
+    };
+    let mut names_buf = vec![0; 4096];
+    let ret = supercall::sc_kpm_list(key_cstr.as_c_str(), &mut names_buf);
+    if ret < 0 {
+        return Err(anyhow::anyhow!("System call failed with error code {}", ret))
+    }
+
+    let names = CStr::from_bytes_until_nul(&names_buf)
+        .map_err(|_| anyhow::anyhow!("Invalid module names buffer"))?
+        .to_str()
+        .map_err(|_| anyhow::anyhow!("Invalid UTF-8 in module names"))?;
+
+    let infos: Vec<_> = names
+        .split('\n')
+        .filter(|name| !name.is_empty())
+        .map(|name| module_info(key_cstr.clone(), name.to_string()))
+        .collect::<Result<_, _>>()?;
+
+    println!("{}", serde_json::to_string_pretty(&infos)?);
+
+    return Ok(())
+}

--- a/apd/src/kpm.rs
+++ b/apd/src/kpm.rs
@@ -53,11 +53,8 @@ fn module_info(key_cstr: CString, name: String) -> anyhow::Result<ModuleInfo> {
     return Ok(info)
 }
 
-pub fn load_module(superkey: Option<String>, path: String) -> anyhow::Result<()> {
-    let key_cstr = match superkey {
-        Some(x) => CString::new(x).map_err(|_| anyhow::anyhow!("Invalid key string"))?,
-        None => return Err(anyhow::anyhow!("No superkey provided")),
-    };
+pub fn load_module(key: String, path: String) -> anyhow::Result<()> {
+    let key_cstr = CString::new(key).map_err(|_| anyhow::anyhow!("Invalid key string"))?;
     let path_cstr = CString::new(path).map_err(|_| anyhow::anyhow!("Invalid path string"))?;
     let ret = supercall::sc_kpm_load(key_cstr.as_c_str(),path_cstr.as_c_str(),None,std::ptr::null_mut());
     if ret < 0 {

--- a/apd/src/main.rs
+++ b/apd/src/main.rs
@@ -12,6 +12,8 @@ mod pty;
 mod restorecon;
 mod supercall;
 mod utils;
+mod kpm;
+
 fn main() -> anyhow::Result<()> {
     cli::run()
 }

--- a/apd/src/supercall.rs
+++ b/apd/src/supercall.rs
@@ -33,6 +33,8 @@ const SUPERCALL_SU_LIST: c_long = 0x1103;
 const SUPERCALL_SU_RESET_PATH: c_long = 0x1111;
 const SUPERCALL_SU_GET_SAFEMODE: c_long = 0x1112;
 const SUPERCALL_KPM_LOAD: c_long = 0x1020;
+const SUPERCALL_KPM_LIST: c_long = 0x1031;
+const SUPERCALL_KPM_INFO: c_long = 0x1032;
 
 const SUPERCALL_SCONTEXT_LEN: usize = 0x60;
 
@@ -158,6 +160,35 @@ pub fn sc_kpm_load(key: &CStr, path: &CStr, args: Option<&CStr>, reserved: *mut 
             path.as_ptr(),
             args.map_or(std::ptr::null(), |a| a.as_ptr()),
             reserved,
+        ) as c_long
+    }
+}
+pub fn sc_kpm_list(key: &CStr, names_buf: &mut [u8]) -> c_long {
+    if key.to_bytes().is_empty() {
+        return (-EINVAL).into();
+    }
+    unsafe {
+        syscall(
+            __NR_SUPERCALL,
+            key.as_ptr(),
+            ver_and_cmd(SUPERCALL_KPM_LIST),
+            names_buf.as_mut_ptr(),
+            names_buf.len() as i32,
+        ) as c_long
+    }
+}
+pub fn sc_kpm_info(key: &CStr, name: &CStr, info_buf: &mut [u8]) -> c_long {
+    if key.to_bytes().is_empty() {
+        return (-EINVAL).into();
+    }
+    unsafe {
+        syscall(
+            __NR_SUPERCALL,
+            key.as_ptr(),
+            ver_and_cmd(SUPERCALL_KPM_INFO),
+            name.as_ptr(),
+            info_buf.as_mut_ptr(),
+            info_buf.len() as i32,
         ) as c_long
     }
 }


### PR DESCRIPTION
I find it quite helpful to be able to retrieve a list of installed KPM via the CLI. For that purpose, I implemented the desired functionality in the APD CLI.

**I am not familiar with Rust** so this is a best-effort implementation, but I attempted to follow your existing code structure.

Short summary of changes:

- Moved existing KPM CLI implementation to separate file (KPM Load)
- Implement supercall functions for KPM_INFO and KPM_LIST
- Implement KPM List CLI function

**Notice**
I noticed the KPM Load command is not using cli.superkey, but I went ahead and used it for the KPM list command. Maybe it would make sense for KPM load to also use cli.superkey? But I don't know how to keep backwards compatibility with that change.

**Example Output**
```
Pacman:/ # apd -s <superkey> kpm list                                                                                                                                                                                                                   
[
  {
    "name": "module1",
    "version": "1.0.0",
    "author": "NilaTheDragon",
    "description": "Cool Kernel Module 1",
    "args": "(null)",
    "license": "GPL v2"
  },
  {
    "name": "module2",
    "version": "1.0.0",
    "author": "NilaTheDragon",
    "description": "Cool Kernel Module 2",
    "args": "(null)",
    "license": "GPL v2"
  }
]
```