### PR TITLE
Show default selinux context as untrusted_app

### DIFF
--- a/app/src/main/java/me/bmax/apatch/APatchApp.kt
+++ b/app/src/main/java/me/bmax/apatch/APatchApp.kt
@@ -64,6 +64,7 @@ class APApplication : Application(), Thread.UncaughtExceptionHandler {
         private const val BUSYBOX_BIN_PATH = APATCH_BIN_FOLDER + "busybox"
         private const val RESETPROP_BIN_PATH = APATCH_BIN_FOLDER + "resetprop"
         private const val MAGISKBOOT_BIN_PATH = APATCH_BIN_FOLDER + "magiskboot"
+        const val DEFAULT_SCONTEXT = "u:r:untrusted_app:s0"
         const val MAGISK_SCONTEXT = "u:r:magisk:s0"
 
         private const val DEFAULT_SU_PATH = "/system/bin/kp"

--- a/app/src/main/java/me/bmax/apatch/Natives.kt
+++ b/app/src/main/java/me/bmax/apatch/Natives.kt
@@ -16,7 +16,7 @@ object Natives {
     data class Profile(
         var uid: Int = 0,
         var toUid: Int = 0,
-        var scontext: String = APApplication.MAGISK_SCONTEXT,
+        var scontext: String = APApplication.DEFAULT_SCONTEXT,
     ) : Parcelable
 
     @Keep

--- a/app/src/main/java/me/bmax/apatch/util/PkgConfig.kt
+++ b/app/src/main/java/me/bmax/apatch/util/PkgConfig.kt
@@ -77,6 +77,7 @@ object PkgConfig {
                 // Root App should not be excluded
                 if (config.allow == 1) {
                     config.exclude = 0
+                    config.profile.scontext = APApplication.MAGISK_SCONTEXT
                 }
                 if (config.allow == 0 && configs[uid] != null && config.exclude != 0) {
                     configs.remove(uid)


### PR DESCRIPTION
In the CONFIG_FILE, there is a field for selinux context label. Though this field is not wildely used by APatch or Android modules, it is confusing to have its default always to be `magisk`.

For example, if one sets an app to be excluded, then in the file `/data/adb/ap/package_config`, its selinux context is shown to be `u:r:magisk:s0`, which is not reasonable. It is better to use the Android default context for applications to avoid confusions (of module developers who parse this file).