### PR TITLE
app: Fix fmt string mismatch and use `ContextCompat`

### DIFF
--- a/app/src/main/java/me/bmax/apatch/util/Downloader.kt
+++ b/app/src/main/java/me/bmax/apatch/util/Downloader.kt
@@ -114,7 +114,6 @@ fun DownloadListener(context: Context, onDownloaded: (Uri) -> Unit) {
                 }
             }
         }
-        // 使用 ContextCompat 注册广播接收器并添加 RECEIVER_NOT_EXPORTED 标志
         val intentFilter = IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
         ContextCompat.registerReceiver(
             context,

--- a/app/src/main/java/me/bmax/apatch/util/Downloader.kt
+++ b/app/src/main/java/me/bmax/apatch/util/Downloader.kt
@@ -12,6 +12,7 @@ import android.os.Environment
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import me.bmax.apatch.apApp
+import androidx.core.content.ContextCompat
 
 @SuppressLint("Range")
 fun download(
@@ -113,17 +114,14 @@ fun DownloadListener(context: Context, onDownloaded: (Uri) -> Unit) {
                 }
             }
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(
-                receiver,
-                IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-                Context.RECEIVER_EXPORTED
-            )
-        } else {
-            context.registerReceiver(
-                receiver, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
-            )
-        }
+        // 使用 ContextCompat 注册广播接收器并添加 RECEIVER_NOT_EXPORTED 标志
+        val intentFilter = IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
+        ContextCompat.registerReceiver(
+            context,
+            receiver,
+            intentFilter,
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
         onDispose {
             context.unregisterReceiver(receiver)
         }

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -30,7 +30,7 @@
     <string name="apatch_version_update">Versiya:
 \n%s -&gt; %s</string>
     <string name="home_su_path">su: %s</string>
-    <string name="kpatch_version">Versiya: %d.%d.%d</string>
+    <string name="kpatch_version">Versiya: %s</string>
     <string name="kernel_patch">NüvəYamağı</string>
     <string name="android_patch">AndroidYamağı</string>
     <string name="home_apatch_version">APatch: %s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -24,7 +24,7 @@
     <string name="apm_start_downloading">Download di %s avviato</string>
     <string name="su_selinux_via_hook">Aggira tramite hook</string>
     <string name="home_ap_cando_uninstall">Disinstalla</string>
-    <string name="apatch_version">Versione: %d.%d.%d</string>
+    <string name="apatch_version">Versione: %s</string>
     <string name="apm_overlay_fs_not_available">I moduli non sono disponibili poiché OverlayFS è disabilitato dal kernel.</string>
     <string name="kpm_version">Versione</string>
     <string name="su_refresh">Ricarica</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -28,7 +28,7 @@
     <string name="home_install_unknown">Tidak diketahui</string>
     <string name="home_click_to_install">Tekan untuk pasang</string>
     <string name="home_need_update">Versi baharu tersedia</string>
-    <string name="kpatch_version">Versi: %d.%d.%d</string>
+    <string name="kpatch_version">Versi: %s</string>
     <string name="apatch_version">Versi: %s</string>
     <string name="home_install_unknown_summary">Tekan untuk pasang</string>
     <string name="success">Berjaya</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -20,7 +20,7 @@
     <string name="home_working">Arbeider</string>
     <string name="home_installing">Installerer</string>
     <string name="home_need_update">Ny versjon tilgjengelig</string>
-    <string name="kpatch_version">Versjon: %d.%d.%d</string>
+    <string name="kpatch_version">Versjon: %s</string>
     <string name="apatch_version_update">Versjon: %s → %s</string>
     <string name="home_su_path">su: %s</string>
     <string name="home_auth_key_desc">Start kjøring etter sertifisering</string>


### PR DESCRIPTION
pixel 4xl lineageOS22 安卓15 和 redmi pad 安卓15 使用 apatch 11039 都无法root

自行使用 KernelPatch 0.12.0 都可以成功root 但是apatch 显示让我反向更新

发现 apatch main 分支提供了 已经提交了 KernelPatch 0.12.0 支持 于是想自行编译下

一直打包不成功,原来是android studio 版本太低的问题. 升级 android studio 解决了.这代码提交不提交无所谓了.

低版本 android studio 打包时修改的代码

registerReceiver 修改的更优雅

string.xml 中 apatch_version 有的是 Version: %s 有的是 Versi: %d.%d.%d
可能是个别语言 编码问题,我认为阿拉伯数字的字符串应该是通用的
我统一改成了 %s

不知道改的对不对

另外不知道为什么 我发布 签名发布 release 版本全部闪退
不签名 debug 版本就没问题

