### PR TITLE
use grep for overlayfs detection instead of cat | grep

### DIFF
--- a/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
+++ b/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
@@ -259,7 +259,7 @@ fun reboot(reason: String = "") {
 
 fun overlayFsAvailable(): Boolean {
     val shell = getRootShell()
-    return ShellUtils.fastCmdResult(shell, "cat /proc/filesystems | grep overlay")
+    return ShellUtils.fastCmdResult(shell, "grep overlay /proc/filesystems")
 }
 
 fun hasMagisk(): Boolean {


### PR DESCRIPTION
It is a very small change but avoids using pipeline