### PR TITLE
manager: left-align WebUI button and add dedicated webui icon

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/APM.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/APM.kt
@@ -534,7 +534,6 @@ private fun ModuleItem(
                         .fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Spacer(modifier = Modifier.weight(1f))
                     if (updateUrl.isNotEmpty()) {
                         ModuleUpdateButton(onClick = { onUpdate(module) })
 
@@ -549,7 +548,7 @@ private fun ModuleItem(
                         ) {
                             Icon(
                                 modifier = Modifier.size(20.dp),
-                                painter = painterResource(id = R.drawable.settings),
+                                painter = painterResource(id = R.drawable.webui),
                                 contentDescription = null
                             )
 
@@ -564,6 +563,8 @@ private fun ModuleItem(
 
                         Spacer(modifier = Modifier.width(12.dp))
                     }
+
+                    Spacer(modifier = Modifier.weight(1f))
 
                     if (module.hasActionScript) {
                         FilledTonalButton(

--- a/app/src/main/res/drawable/webui.xml
+++ b/app/src/main/res/drawable/webui.xml
@@ -1,0 +1,41 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M3,12a9,9 0,1 0,18 0a9,9 0,0 0,-18 0"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffff"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M3.6,9h16.8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffff"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M3.6,15h16.8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffff"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M11.5,3a17,17 0,0 0,0 18"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffff"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M12.5,3a17,17 0,0 1,0 18"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffff"
+        android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
We noticed the WebUI icon was the same as the action icons, which made it hard to tell them apart.
Now the WebUI button is on the left, update and uninstall/action buttons stay on the right.
The old icon is replaced with a new dedicated WebUI icon (webui.xml).
Layout looks good in light/dark themes, and all buttons still work.

**This change has been verified and passed stability testing.**