### PR TITLE
manager: fix update module download listener callback not firing

### DIFF
--- a/app/src/main/java/me/bmax/apatch/util/Downloader.kt
+++ b/app/src/main/java/me/bmax/apatch/util/Downloader.kt
@@ -119,7 +119,7 @@ fun DownloadListener(context: Context, onDownloaded: (Uri) -> Unit) {
             context,
             receiver,
             intentFilter,
-            ContextCompat.RECEIVER_NOT_EXPORTED
+            ContextCompat.RECEIVER_EXPORTED
         )
         onDispose {
             context.unregisterReceiver(receiver)


### PR DESCRIPTION
The update module's download listener sometimes failed to trigger the `onDownloaded` callback. This happened because the receiver was registered with `RECEIVER_NOT_EXPORTED`, so it only received broadcasts sent internally by the app. System broadcasts were being blocked, as shown in the logs:

```yaml
2025-11-30 09:40:38.926 2100-2265 BroadcastQueue pid-2100 W Exported Denial: 
sending Intent { 
    act=android.intent.action.DOWNLOAD_COMPLETE 
    flg=0x10 
    pkg=me.bmax.apatch (has extras) 
}, 
action: android.intent.action.DOWNLOAD_COMPLETE 
from com.android.providers.downloads (uid=10066) 
due to receiver ProcessRecord{e74cb09 15564:me.bmax.apatch/u0a284} (uid 10284) 
not specifying RECEIVER_EXPORTED
```

Changing the registration to `RECEIVER_EXPORTED` allows the receiver to receive these system broadcasts, so the callback is invoked properly when a download finishes.

This fixes the issue where module downloads could complete but the installation callback was never triggered, without affecting other parts of the app.

**The change has been tested and confirmed to allow module updates to complete and install correctly.**

**Reference:**
[Android broadcast](https://developer.android.com/develop/background-work/background-tasks/broadcasts)