### PR TITLE
manager: fix misleading install log reset on InstallScreen

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/Install.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Install.kt
@@ -59,7 +59,7 @@ enum class MODULE_TYPE {
 @Composable
 @Destination<RootGraph>
 fun InstallScreen(navigator: DestinationsNavigator, uri: Uri, type: MODULE_TYPE) {
-    var text by remember { mutableStateOf("") }
+    var text by rememberSaveable { mutableStateOf("") }
     var tempText: String
     val logContent = remember { StringBuilder() }
     var showFloatAction by rememberSaveable { mutableStateOf(false) }


### PR DESCRIPTION
Previously, navigating back to InstallScreen caused the install log to reset, making it appear as if the module was being reinstalled. The issue was that `text` was stored with `remember`, which does not survive recomposition when the composable is recreated. Logs confirmed that this is not caused by repeated navigation, but by recomposition resetting the state.

This commit updates `text` to use `rememberSaveable`, ensuring that the install log state is preserved across navigation and configuration changes. The log now correctly accumulates output without being cleared, preventing misleading re-install behavior.

**This change has been tested to verify.**

**Reference:** https://developer.android.com/develop/ui/compose/state
