### PR TITLE
feat: Add SuperUser global one-click exclusion feature

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/component/SearchBar.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/component/SearchBar.kt
@@ -51,6 +51,7 @@ fun SearchAppBar(
     onBackClick: (() -> Unit)? = null,
     onConfirm: (() -> Unit)? = null,
     dropdownContent: @Composable (() -> Unit)? = null,
+    leadingActions: @Composable (() -> Unit)? = null,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
@@ -144,10 +145,15 @@ fun SearchAppBar(
             AnimatedVisibility(
                 visible = !onSearch
             ) {
-                IconButton(
-                    onClick = { onSearch = true },
-                    content = { Icon(Icons.Filled.Search, null) }
-                )
+                androidx.compose.foundation.layout.Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    leadingActions?.invoke()
+                    IconButton(
+                        onClick = { onSearch = true },
+                        content = { Icon(Icons.Filled.Search, null) }
+                    )
+                }
             }
 
             dropdownContent?.invoke()

--- a/app/src/main/java/me/bmax/apatch/ui/screen/SuperUser.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/SuperUser.kt
@@ -18,7 +18,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PlaylistAddCheck
 import androidx.compose.material.icons.filled.Security
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -28,6 +30,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -66,6 +69,31 @@ import me.bmax.apatch.util.PkgConfig
 fun SuperUserScreen() {
     val viewModel = viewModel<SuperUserViewModel>()
     val scope = rememberCoroutineScope()
+    var showBatchExcludeDialog by remember { mutableStateOf(false) }
+
+    if (showBatchExcludeDialog) {
+        AlertDialog(
+            onDismissRequest = { showBatchExcludeDialog = false },
+            title = { Text(stringResource(R.string.su_batch_exclude_title)) },
+            text = { Text(stringResource(R.string.su_batch_exclude_content)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.excludeAll()
+                    showBatchExcludeDialog = false
+                }) {
+                    Text(stringResource(R.string.su_exclude_btn))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    viewModel.reverseExcludeAll()
+                    showBatchExcludeDialog = false
+                }) {
+                    Text(stringResource(R.string.su_exclude_reverse_btn))
+                }
+            }
+        )
+    }
 
     LaunchedEffect(Unit) {
         if (viewModel.appList.isEmpty()) {
@@ -80,6 +108,11 @@ fun SuperUserScreen() {
                 searchText = viewModel.search,
                 onSearchTextChange = { viewModel.search = it },
                 onClearClick = { viewModel.search = "" },
+                leadingActions = {
+                    IconButton(onClick = { showBatchExcludeDialog = true }) {
+                        Icon(Icons.Filled.PlaylistAddCheck, null)
+                    }
+                },
                 dropdownContent = {
                     var showDropdown by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/me/bmax/apatch/util/PkgConfig.kt
+++ b/app/src/main/java/me/bmax/apatch/util/PkgConfig.kt
@@ -88,4 +88,28 @@ object PkgConfig {
             }
         }
     }
+
+    fun batchChangeConfigs(newConfigs: List<Config>) {
+        thread {
+            synchronized(PkgConfig.javaClass) {
+                Natives.su()
+                val configs = readConfigs()
+
+                newConfigs.forEach { config ->
+                    val uid = config.profile.uid
+                    // Root App should not be excluded
+                    if (config.allow == 1) {
+                        config.exclude = 0
+                    }
+
+                    if (config.isDefault() && configs[uid] != null) {
+                        configs.remove(uid)
+                    } else {
+                        configs[uid] = config
+                    }
+                }
+                writeConfigs(configs)
+            }
+        }
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,10 @@
     <string name="su_show_system_apps">Show system apps</string>
     <string name="su_hide_system_apps">Hide system apps</string>
     <string name="su_refresh">Refresh</string>
+    <string name="su_batch_exclude_title">Batch Exclude</string>
+    <string name="su_batch_exclude_content">Exclude injection for all non-ROOT apps, please select an action</string>
+    <string name="su_exclude_btn">Exclude</string>
+    <string name="su_exclude_reverse_btn">Reverse</string>
 
     <string name="apm">APModule</string>
     <string name="apm_not_installed">AndroidPatch not installed</string>


### PR DESCRIPTION
## Feature Description
Add SuperUser global one-click exclusion feature that allows users to quickly exclude all unauthorized applications with a single tap.

## Changes Made
- Added `excludeAll()` method in SuperUserViewModel to exclude all unauthorized applications
- Added `reverseExcludeAll()` method to toggle exclusion status for all applications
- Updated application list sorting logic to ensure excluded applications are properly sorted
- Enhanced user experience with batch operations

## Testing Steps
1. Open APatch application
2. Navigate to SuperUser management interface
3. Test "Global Exclude" functionality
4. Test "Reverse Global Exclude" functionality
5. Verify that exclusion status is correctly saved and displayed

## Compatibility
- Fully compatible with existing functionality
- Does not affect existing application permission settings
- Maintains backward compatibility

## Additional Information
Migrated from FolkPatch project to bring this useful feature to APatch
