### PR TITLE
manager: prevent module update crash by safely reading HTTP response

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/APM.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/APM.kt
@@ -276,13 +276,15 @@ private fun ModuleList(
     ) {
         val changelog = loadingDialog.withLoading {
             withContext(Dispatchers.IO) {
-                if (Patterns.WEB_URL.matcher(changelogUrl).matches()) {
-                    apApp.okhttpClient.newCall(
-                        okhttp3.Request.Builder().url(changelogUrl).build()
-                    ).execute().body!!.string()
-                } else {
-                    changelogUrl
-                }
+                runCatching {
+                    if (Patterns.WEB_URL.matcher(changelogUrl).matches()) {
+                        apApp.okhttpClient.newCall(
+                                okhttp3.Request.Builder().url(changelogUrl).build()
+                            ).execute().use { it.body?.string().orEmpty() }
+                    } else {
+                        changelogUrl
+                    }
+                }.getOrDefault("")
             }
         }
 


### PR DESCRIPTION
This PR prevents a module update crash caused by null HTTP response bodies. Previously, calling body!!.string() would crash if the changelog request returned null, which can happen if the JSON is fetched correctly but the changelog content fails to load (e.g., due to proxy/network issues).

Now, the response is safely read with body?.string().orEmpty() inside runCatching().getOrDefault(""), so empty or failed responses won’t cause a crash. The update behavior itself is unchanged, and module downloads continue silently even if the changelog is empty.

<details>
<summary>Crash log</summary>

```
APatch version: 77dd98b (11218)

Brand: Redmi
Model: 22021211RC
SDK Level: 34
Time: 2025-12-19 16:24:15

Thread: main
Crash Info: 
java.net.ConnectException: Failed to connect to raw.githubusercontent.com/[::]:443
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.kt:297)
	at okhttp3.internal.connection.RealConnection.connect(RealConnection.kt:207)
	at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.kt:226)
	at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.kt:106)
	at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.kt:74)
	at okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.kt:255)
	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at me.bmax.apatch.APApplication$onCreate$$inlined$-addInterceptor$1.intercept(OkHttpClient.kt:1080)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
	at okhttp3.internal.connection.RealCall.execute(RealCall.kt:154)
	at me.bmax.apatch.ui.screen.APMKt$ModuleList$onModuleUpdate$changelog$1$1.invokeSuspend(APM.kt:259)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
	Suppressed: java.net.ConnectException: Failed to connect to raw.githubusercontent.com/0.0.0.0:443
		... 27 more
	Caused by: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 443) from /127.0.0.1 (port 38452) after 10000ms: isConnected failed: ECONNREFUSED (Connection refused)
		at libcore.io.IoBridge.isConnected(IoBridge.java:347)
		at libcore.io.IoBridge.connectErrno(IoBridge.java:237)
		at libcore.io.IoBridge.connect(IoBridge.java:179)
		at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:142)
		at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:390)
		at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:228)
		at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:212)
		at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:436)
		at java.net.Socket.connect(Socket.java:646)
		at okhttp3.internal.platform.Platform.connectSocket(Platform.kt:128)
		at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.kt:295)
		... 26 more
	Caused by: android.system.ErrnoException: isConnected failed: ECONNREFUSED (Connection refused)
		at libcore.io.IoBridge.isConnected(IoBridge.java:334)
		... 36 more
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [androidx.compose.ui.platform.MotionDurationScaleImpl@2026b30, androidx.compose.runtime.BroadcastFrameClock@ed073a9, StandaloneCoroutine{Cancelling}@fb4ed2e, AndroidUiDispatcher@fe130cf]
Caused by: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 443) from /127.0.0.1 (port 38454) after 10000ms: isConnected failed: ECONNREFUSED (Connection refused)
	at libcore.io.IoBridge.isConnected(IoBridge.java:347)
	at libcore.io.IoBridge.connectErrno(IoBridge.java:237)
	at libcore.io.IoBridge.connect(IoBridge.java:179)
	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:142)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketIm
```

</details>

Fixes #1123 (issue 2).
