### PR TITLE
apd/manager: implement undo functionality for module uninstallation

### DIFF
--- a/apd/src/cli.rs
+++ b/apd/src/cli.rs
@@ -63,6 +63,12 @@ enum Module {
         id: String,
     },
 
+    /// UudoUninstall module <id>
+    UndoUninstall {
+        /// module id
+        id: String,
+    },
+
     /// enable module <id>
     Enable {
         /// module id
@@ -154,6 +160,7 @@ pub fn run() -> Result<()> {
             match command {
                 Module::Install { zip } => module::install_module(&zip),
                 Module::Uninstall { id } => module::uninstall_module(&id),
+                Module::UndoUninstall { id } => module::undo_uninstall_module(&id),
                 Module::Action { id } => module::run_action(&id),
                 Module::Lua { id, function } => {
                     lua::run_lua(&id, &function, false, true).map_err(|e| anyhow::anyhow!("{}", e))

--- a/apd/src/module.rs
+++ b/apd/src/module.rs
@@ -526,6 +526,47 @@ pub fn uninstall_module(id: &str) -> Result<()> {
     Ok(())
 }
 
+pub fn _undo_uninstall_module(id: &str, update_dir: &str) -> Result<()> {
+    let dir = Path::new(update_dir);
+    ensure!(dir.exists(), "No module installed");
+
+    let mut found = false;
+    for entry in fs::read_dir(dir)?.flatten() {
+        let path = entry.path();
+        let module_prop = path.join("module.prop");
+        if !module_prop.exists() {
+            continue;
+        }
+
+        let content = fs::read(&module_prop)?;
+        let mut module_id = String::new();
+
+        PropertiesIter::new_with_encoding(Cursor::new(content), encoding_rs::UTF_8,).read_into(
+            |k, v| {
+                if k == "id" {
+                    module_id = v;
+                }
+            }
+        )?;
+        if module_id == id {
+            let remove_file = path.join(defs::REMOVE_FILE_NAME);
+            fs::remove_file(remove_file).with_context(|| "Failed to remove removefile.")?;
+            found = true;
+            break;
+        }
+    }
+
+    ensure!(found, "Module not found");
+
+    let _ = mark_module_state(id, defs::REMOVE_FILE_NAME, false);
+    Ok(())
+}
+pub fn undo_uninstall_module(id: &str) -> Result<()> {
+    _undo_uninstall_module(id, defs::MODULE_DIR)?;
+    mark_update()?;
+    Ok(())
+}
+
 /// Read module.prop from the given module path and return as a HashMap
 pub fn read_module_prop(module_path: &Path) -> Result<HashMap<String, String>> {
     let module_prop = module_path.join("module.prop");

--- a/app/src/main/java/me/bmax/apatch/ui/component/ModuleCardComponents.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/component/ModuleCardComponents.kt
@@ -3,21 +3,17 @@ package me.bmax.apatch.ui.component
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import me.bmax.apatch.R
 
@@ -44,6 +40,19 @@ fun ModuleRemoveButton(
         modifier = Modifier.size(20.dp),
         painter = painterResource(id = R.drawable.trash),
         contentDescription = stringResource(id = R.string.apm_remove)
+    )
+}
+
+@Composable
+fun ModuleUndoRemoveButton(
+    enabled: Boolean, onClick: () -> Unit
+) = FilledTonalButton(
+    onClick = onClick, enabled = enabled, contentPadding = PaddingValues(12.dp)
+) {
+    Icon(
+        modifier = Modifier.size(20.dp),
+        painter = painterResource(id = R.drawable.undo),
+        contentDescription = stringResource(id = R.string.apm_undo)
     )
 }
 

--- a/app/src/main/java/me/bmax/apatch/ui/screen/APM.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/APM.kt
@@ -92,6 +92,7 @@ import me.bmax.apatch.ui.WebUIActivity
 import me.bmax.apatch.ui.component.ConfirmResult
 import me.bmax.apatch.ui.component.ModuleRemoveButton
 import me.bmax.apatch.ui.component.ModuleStateIndicator
+import me.bmax.apatch.ui.component.ModuleUndoRemoveButton
 import me.bmax.apatch.ui.component.ModuleUpdateButton
 import me.bmax.apatch.ui.component.SearchAppBar
 import me.bmax.apatch.ui.component.WarningCard
@@ -105,6 +106,7 @@ import me.bmax.apatch.util.hasMagisk
 import me.bmax.apatch.util.reboot
 import me.bmax.apatch.util.toggleModule
 import me.bmax.apatch.util.ui.LocalSnackbarHost
+import me.bmax.apatch.util.undoRemoveModule
 import me.bmax.apatch.util.uninstallModule
 import okhttp3.Request
 
@@ -307,7 +309,9 @@ private fun ModuleList(
     val failedEnable = stringResource(R.string.apm_failed_to_enable)
     val failedDisable = stringResource(R.string.apm_failed_to_disable)
     val failedUninstall = stringResource(R.string.apm_uninstall_failed)
+    val failedUndoUninstall = stringResource(R.string.apm_module_undo_uninstall_failed)
     val successUninstall = stringResource(R.string.apm_uninstall_success)
+    val successUndoUninstall = stringResource(R.string.apm_module_undo_uninstall_success)
     val reboot = stringResource(id = R.string.reboot)
     val rebootToApply = stringResource(id = R.string.apm_reboot_to_apply)
     val moduleStr = stringResource(id = R.string.apm)
@@ -420,6 +424,34 @@ private fun ModuleList(
         }
     }
 
+    suspend fun onUndoModuleUninstall(module: APModuleViewModel.ModuleInfo) {
+        val success = loadingDialog.withLoading {
+            withContext(Dispatchers.IO) {
+                undoRemoveModule(module.id)
+            }
+        }
+
+        if (success) {
+            viewModel.fetchModuleList()
+        }
+        val message = if (success) {
+            successUndoUninstall.format(module.name)
+        } else {
+            failedUndoUninstall.format(module.name)
+        }
+        val actionLabel = if (success) {
+            reboot
+        } else {
+            null
+        }
+        val result = snackBarHost.showSnackbar(
+            message = message, actionLabel = actionLabel, duration = SnackbarDuration.Long
+        )
+        if (result == SnackbarResult.ActionPerformed) {
+            reboot()
+        }
+    }
+
     PullToRefreshBox(
         modifier = modifier,
         onRefresh = { viewModel.fetchModuleList() },
@@ -477,6 +509,9 @@ private fun ModuleList(
                             updateInfo?.zipUrl ?: "",
                             onUninstall = {
                                 scope.launch { onModuleUninstall(module) }
+                            },
+                            onUndoUninstall = {
+                                scope.launch { onUndoModuleUninstall(module) }
                             },
                             onCheckChanged = {
                                 scope.launch {
@@ -536,6 +571,7 @@ private fun ModuleItem(
     isChecked: Boolean,
     updateUrl: String,
     onUninstall: (APModuleViewModel.ModuleInfo) -> Unit,
+    onUndoUninstall: (APModuleViewModel.ModuleInfo) -> Unit,
     onCheckChanged: (Boolean) -> Unit,
     onUpdate: (APModuleViewModel.ModuleInfo) -> Unit,
     onClick: (APModuleViewModel.ModuleInfo) -> Unit,
@@ -679,8 +715,6 @@ private fun ModuleItem(
                         Spacer(modifier = Modifier.width(12.dp))
                     }
 
-                    Spacer(modifier = Modifier.weight(1f))
-
                     if (module.hasActionScript) {
                         FilledTonalButton(
                             onClick = {
@@ -697,7 +731,20 @@ private fun ModuleItem(
 
                         Spacer(modifier = Modifier.width(12.dp))
                     }
-                    ModuleRemoveButton(enabled = !module.remove, onClick = { onUninstall(module) })
+
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    if (!module.remove) {
+                        ModuleRemoveButton(
+                            enabled = true,
+                            onClick = { onUninstall(module) }
+                        )
+                    } else {
+                        ModuleUndoRemoveButton(
+                            enabled = true,
+                            onClick = { onUndoUninstall(module) }
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
+++ b/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
@@ -258,6 +258,13 @@ fun uninstallModule(id: String): Boolean {
     return result
 }
 
+fun undoRemoveModule(id: String): Boolean {
+    val cmd = "module undo-uninstall $id"
+    val result = execApd(cmd,true)
+    Log.i(TAG, "undo-uninstall module $id result: $result")
+    return result
+}
+
 fun installModule(
     uri: Uri, type: MODULE_TYPE, onFinish: (Boolean) -> Unit, onStdout: (String) -> Unit, onStderr: (String) -> Unit
 ): Boolean {

--- a/app/src/main/res/drawable/undo.xml
+++ b/app/src/main/res/drawable/undo.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M280,760v-80h284q63,0 109.5,-40T720,540q0,-60 -46.5,-100T564,400L312,400l104,104 -56,56 -200,-200 200,-200 56,56 -104,104h252q97,0 166.5,63T800,540q0,94 -69.5,157T564,760L280,760Z"
+      android:fillColor="#1f1f1f"/>
+</vector>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -84,6 +84,7 @@
     <string name="apm_uninstall_success">%s 已卸载</string>
     <string name="apm_install">安装</string>
     <string name="apm_remove">卸载</string>
+    <string name="apm_undo">撤销</string>
     <string name="apm_uninstall_confirm">确认要卸载“%s”模块吗？</string>
     <string name="metamodule_uninstall_confirm">"您确定要卸载模块 %s 吗？此操作将影响所有模块，并且元模块提供的某些功能（如挂载）将不再工作。  "</string>
     <string name="warning_of_meta_module_title">需要元模块</string>
@@ -96,6 +97,8 @@
     <string name="apm_overlay_fs_not_available">模块功能不可用，因为内核禁用了 OverlayFS！</string>
     <string name="apm_changelog">更新日志</string>
     <string name="apm_uninstall_failed">无法卸载 %s</string>
+    <string name="apm_module_undo_uninstall_success">%s 已恢复</string>
+    <string name="apm_module_undo_uninstall_failed">%s 恢复失败</string>
     <string name="apm_downloading">正在下载“%s”模块……</string>
     <string name="apm_magisk_conflict">模块功能不可用，因与 Magisk 存在冲突！</string>
     <string name="apm_desc">描述</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,11 +153,14 @@
     <string name="apm_failed_to_disable">Failed to disable module: %s</string>
     <string name="apm_empty">No module installed</string>
     <string name="apm_remove">Remove</string>
+    <string name="apm_undo">Undo</string>
     <string name="apm_install">Install</string>
     <string name="apm_uninstall_confirm">Uninstall the %s module?</string>
     <string name="metamodule_uninstall_confirm">"Are you sure you want to uninstall module %s? This action will affect all modules, and certain features provided by the metamodule (such as mounting) will no longer work.  "</string>
     <string name="apm_uninstall_success">%s uninstalled</string>
     <string name="apm_uninstall_failed">Failed to uninstall: %s</string>
+    <string name="apm_module_undo_uninstall_success">Successfully canceled uninstall of %s</string>
+    <string name="apm_module_undo_uninstall_failed">Failed to undo uninstall: %s</string>
     <string name="apm_version">Version</string>
     <string name="apm_author">Author</string>
     <string name="apm_desc">Desc</string>


### PR DESCRIPTION
## Background
This PR adds support for undoing a pending module uninstallation before a reboot is performed. This addresses the inconvenience of having to manually reinstall a module if the "Uninstall" button was clicked by mistake.

## Key Changes

### 1. apd
- **Added** `undo-uninstall` command to the CLI.
- **Implemented** `_undo_uninstall_module` to clear the pending removal flag and restore the internal module state.
- **Standardized** the implementation between `uninstall` and `undo_uninstall` to ensure consistent state management and `mark_update` calls.

### 2. Manager
- **Adaptive Button**: The uninstall button now dynamically toggles to an "Undo" button (with a new icon) when a module is marked for removal.
- **Improved Feedback**: Integrated a Snackbar with a "Reboot" action upon a successful undo, matching the existing uninstallation flow.
- **Layout Refactor**: Reorganized the `ModuleItem` action bar for better logical grouping:
  - **Functional group (Left)**: `WebUI` and `ActionScript` are now on the left for quicker access.
  - **State group (Right)**: `Update` and `Uninstall/Undo` are grouped on the right.
- **State Guard**: Wrapped the undo operation in a `loadingDialog` to prevent race conditions during the CLI execution.

## Test
- [x] Verified `apd` CLI correctly removes the pending removal flag and updates module state.
- [x] Verified Manager UI correctly toggles buttons and handles the undo workflow.
- [x] Confirmed Snackbar and Reboot actions function as intended.