### PR TITLE
manager: enforce strong superkey requirement for patching

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/Patches.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Patches.kt
@@ -249,8 +249,11 @@ fun Patches(mode: PatchesViewModel.PatchMode) {
             if (!viewModel.patching && !viewModel.patchdone) {
                 // patch start
                 if (mode != PatchesViewModel.PatchMode.UNPATCH) {
-                    StartButton(stringResource(id = R.string.patch_start_patch_btn)) {
-                        viewModel.doPatch(mode, needKey)
+                    val isKeyReady = !needKey || viewModel.superkey.isNotEmpty()
+                    if (isKeyReady) {
+                        StartButton(stringResource(id = R.string.patch_start_patch_btn)) {
+                            viewModel.doPatch(mode, needKey)
+                        }
                     }
                 }
                 // unpatch


### PR DESCRIPTION
- Prevent the patch process from starting with a weak or invalid superkey.
- Fix a UI logic gap where the patch button ignored ViewModel validation results.
- Ensure the start button is only visible when the custom superkey satisfies security requirements (if enabled).