### PR TITLE
Update to match KP's `kstorage` read/write (PR extension)

### DIFF
--- a/apd/src/supercall.rs
+++ b/apd/src/supercall.rs
@@ -36,6 +36,13 @@ struct SuProfile {
     scontext: [u8; SUPERCALL_SCONTEXT_LEN],
 }
 
+#[repr(C)]
+struct DataItem {
+    data: *mut c_void,
+    dlen: i32,
+    offset: i32,
+}
+
 fn ver_and_cmd(cmd: c_long) -> c_long {
     let version_code: u32 = ((MAJOR << 16) + (MINOR << 8) + PATCH).try_into().unwrap();
     ((version_code as c_long) << 32) | (0x1158 << 16) | (cmd & 0xFFFF)
@@ -73,9 +80,7 @@ fn sc_kstorage_write(
     key: &CStr,
     gid: i32,
     did: i64,
-    data: *mut c_void,
-    offset: i32,
-    dlen: i32,
+    data: &DataItem,
 ) -> c_long {
     if key.to_bytes().is_empty() {
         return (-EINVAL).into();
@@ -88,19 +93,22 @@ fn sc_kstorage_write(
             gid as c_long,
             did as c_long,
             data,
-            (((offset as i64) << 32) | (dlen as i64)) as c_long,
         ) as c_long
     }
 }
 
 fn sc_set_ap_mod_exclude(key: &CStr, uid: i64, exclude: i32) -> c_long {
+    let data_item = DataItem {
+        data: &exclude as *const i32 as *mut c_void,
+        dlen: size_of::<i32>() as i32,
+        offset: 0,
+    };
+
     sc_kstorage_write(
         key,
         KSTORAGE_EXCLUDE_LIST_GROUP,
         uid,
-        &exclude as *const i32 as *mut c_void,
-        0,
-        size_of::<i32>() as i32,
+        &data_item,
     )
 }
 

--- a/app/src/main/cpp/supercall.h
+++ b/app/src/main/cpp/supercall.h
@@ -147,10 +147,10 @@ static inline long sc_su_task(const char *key, pid_t tid, struct su_profile *pro
  * @param dlen 
  * @return long 
  */
-static inline long sc_kstorage_write(const char *key, int gid, long did, void *data, int offset, int dlen)
+static inline long sc_kstorage_write(const char *key, int gid, long did, struct data_item *data)
 {
     if (!key || !key[0]) return -EINVAL;
-    long ret = syscall(__NR_supercall, key, ver_and_cmd(key, SUPERCALL_KSTORAGE_WRITE), gid, did, data, (((long)offset << 32) | dlen));
+    long ret = syscall(__NR_supercall, key, ver_and_cmd(key, SUPERCALL_KSTORAGE_WRITE), gid, did, data);
     return ret;
 }
 
@@ -164,10 +164,10 @@ static inline long sc_kstorage_write(const char *key, int gid, long did, void *d
  * @param dlen 
  * @return long 
  */
-static inline long sc_kstorage_read(const char *key, int gid, long did, void *out_data, int offset, int dlen)
+static inline long sc_kstorage_read(const char *key, int gid, long did, struct data_item *out_data)
 {
     if (!key || !key[0]) return -EINVAL;
-    long ret = syscall(__NR_supercall, key, ver_and_cmd(key, SUPERCALL_KSTORAGE_READ), gid, did, out_data, (((long)offset << 32) | dlen));
+    long ret = syscall(__NR_supercall, key, ver_and_cmd(key, SUPERCALL_KSTORAGE_READ), gid, did, out_data);
     return ret;
 }
 
@@ -216,7 +216,13 @@ static inline long sc_kstorage_remove(const char *key, int gid, long did)
 static inline long sc_set_ap_mod_exclude(const char *key, uid_t uid, int exclude)
 {
     if(exclude) {
-        return sc_kstorage_write(key, KSTORAGE_EXCLUDE_LIST_GROUP, uid, &exclude, 0, sizeof(exclude));
+        struct data_item data_item = {
+            .data = &exclude,
+            .dlen = sizeof(exclude),
+            .offset = 0,
+        };
+
+        return sc_kstorage_write(key, KSTORAGE_EXCLUDE_LIST_GROUP, uid, &data_item);
     } else {
         return sc_kstorage_remove(key, KSTORAGE_EXCLUDE_LIST_GROUP, uid);
     }
@@ -234,7 +240,12 @@ static inline long sc_set_ap_mod_exclude(const char *key, uid_t uid, int exclude
 static inline int sc_get_ap_mod_exclude(const char *key, uid_t uid)
 {
     int exclude = 0;
-    int rc = sc_kstorage_read(key, KSTORAGE_EXCLUDE_LIST_GROUP, uid, &exclude, 0, sizeof(exclude));
+    struct data_item data_item = {
+        .data = &exclude,
+        .dlen = sizeof(exclude),
+        .offset = 0,
+    };
+    int rc = sc_kstorage_read(key, KSTORAGE_EXCLUDE_LIST_GROUP, uid, &data_item);
     if (rc < 0) return 0;
     return exclude;
 }

--- a/app/src/main/cpp/uapi/scdefs.h
+++ b/app/src/main/cpp/uapi/scdefs.h
@@ -74,6 +74,13 @@ struct su_profile
     char scontext[SUPERCALL_SCONTEXT_LEN];
 };
 
+struct data_item
+{
+    void *data;
+    int dlen;
+    int offset;
+};
+
 #ifdef ANDROID
 #define SH_PATH "/system/bin/sh"
 #define SU_PATH "/system/bin/kp"


### PR DESCRIPTION
This PR is an extension of https://github.com/bmax121/KernelPatch/pull/256 which also updates the "kstorage" methods to allow 32-bit userspace processes to utilize them.