### PR TITLE
manager: restore fallback when truncate fails to create shell

### DIFF
--- a/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
+++ b/app/src/main/java/me/bmax/apatch/util/APatchCli.kt
@@ -80,9 +80,8 @@ fun createRootShell(globalMnt: Boolean = false): Shell {
 private fun createMainRootShell() : Shell {
     val builder = Shell.Builder.create()
         .setInitializers(RootShellInitializer::class.java)
-        .setCommands(SUPERCMD, APApplication.superKey, "-Z", APApplication.MAGISK_SCONTEXT)
     val shell = try {
-        builder.build()
+        builder.build(SUPERCMD, APApplication.superKey, "-Z", APApplication.MAGISK_SCONTEXT)
     } catch (e: Throwable) {
         Log.e(TAG, "su failed: ", e)
         builder.setCommands(getKPatchPath(), APApplication.superKey, "su", "-Z", APApplication.MAGISK_SCONTEXT)


### PR DESCRIPTION
If truncate cannot set up the root shell, the builder was left with the primary command and no fallback was attempted, causing a crash instead of retrying with kpatch or su.

Pass the primary arguments directly inside the try block so the builder remains clean for fallback on failure.