### PR TITLE
apd: fix some module scripts won't add AP_MODULE environment var

### DIFF
--- a/apd/src/metamodule.rs
+++ b/apd/src/metamodule.rs
@@ -66,6 +66,15 @@ pub fn get_metamodule_path() -> Option<PathBuf> {
     result
 }
 
+/// Get Metamodule Id
+pub fn get_metamodule_id() -> Option<String> {
+    get_metamodule_path().and_then(|path| {
+        path.file_name()
+            .and_then(|os_str| os_str.to_str())
+            .map(ToString::to_string)
+    })
+}
+
 /// Check if metamodule exists
 pub fn has_metamodule() -> bool {
     get_metamodule_path().is_some()
@@ -231,7 +240,9 @@ pub fn exec_metauninstall_script(module_id: &str) -> Result<()> {
     let result = Command::new(assets::BUSYBOX_PATH)
         .args(["sh", metauninstall_path.to_str().unwrap()])
         .current_dir(metauninstall_path.parent().unwrap())
-        .envs(crate::module::get_common_script_envs())
+        .envs(crate::module::get_common_script_envs(
+            get_metamodule_id().as_deref(),
+        ))
         .env("MODULE_ID", module_id)
         .status()?;
 
@@ -255,7 +266,9 @@ pub fn exec_mount_script(module_dir: &str) -> Result<()> {
 
     let result = Command::new(assets::BUSYBOX_PATH)
         .args(["sh", mount_script.to_str().unwrap()])
-        .envs(crate::module::get_common_script_envs())
+        .envs(crate::module::get_common_script_envs(
+            get_metamodule_id().as_deref(),
+        ))
         .env("MODULE_DIR", module_dir)
         .status()?;
 

--- a/apd/src/module.rs
+++ b/apd/src/module.rs
@@ -43,7 +43,7 @@ pub enum ModuleType {
     Updated,
 }
 
-fn exec_install_script(module_file: &str, is_metamodule: bool) -> Result<()> {
+fn exec_install_script(module_file: &str, is_metamodule: bool, module_id: &str) -> Result<()> {
     let realpath = std::fs::canonicalize(module_file)
         .with_context(|| format!("realpath: {module_file} failed"))?;
 
@@ -53,7 +53,7 @@ fn exec_install_script(module_file: &str, is_metamodule: bool) -> Result<()> {
 
     let result = Command::new(assets::BUSYBOX_PATH)
         .args(["sh", "-c", &install_script])
-        .envs(get_common_script_envs())
+        .envs(get_common_script_envs(Some(module_id)))
         .env("OUTFD", "1")
         .env("ZIPFILE", realpath)
         .status()?;
@@ -97,8 +97,8 @@ pub fn handle_updated_modules() -> Result<()> {
 }
 
 /// Get common environment variables for script execution
-pub fn get_common_script_envs() -> Vec<(&'static str, String)> {
-    vec![
+pub fn get_common_script_envs(module_id: Option<&str>) -> Vec<(&'static str, String)> {
+    let mut envs = vec![
         ("ASH_STANDALONE", "1".to_string()),
         ("APATCH", "true".to_string()),
         ("APATCH_VER", defs::VERSION_NAME.to_string()),
@@ -111,7 +111,13 @@ pub fn get_common_script_envs() -> Vec<(&'static str, String)> {
                 defs::BINARY_DIR.trim_end_matches('/')
             ),
         ),
-    ]
+    ];
+
+    if let Some(id) = module_id {
+        envs.push(("AP_MODULE", id.to_string()));
+    }
+
+    envs
 }
 
 // because we use something like A-B update
@@ -236,23 +242,7 @@ pub fn exec_script<T: AsRef<Path>>(path: T, wait: bool) -> Result<()> {
         .current_dir(path.as_ref().parent().unwrap())
         .arg("sh")
         .arg(path.as_ref())
-        .env("ASH_STANDALONE", "1")
-        .env("APATCH", "true")
-        .env("APATCH_VER", defs::VERSION_NAME)
-        .env("APATCH_VER_CODE", defs::VERSION_CODE)
-        .env(
-            "PATH",
-            format!(
-                "{}:{}",
-                env_var("PATH")?,
-                defs::BINARY_DIR.trim_end_matches('/')
-            ),
-        );
-
-    // Set AP_MODULE environment variable
-    if let Some(id) = module_id {
-        command = command.env("AP_MODULE", id);
-    }
+        .envs(get_common_script_envs(module_id.as_deref()));
 
     let result = if wait {
         command.status().map(|_| ())
@@ -487,7 +477,7 @@ fn _install_module(zip: &str) -> Result<()> {
     archive.extract(&_module_update_dir)?;
 
     println!("- Running module installer");
-    exec_install_script(zip, is_metamodule)?;
+    exec_install_script(zip, is_metamodule, module_id)?;
 
     // set permission and selinux context for $MOD/system
     let module_system_dir = PathBuf::from(module_dir.clone()).join("system");


### PR DESCRIPTION
AP_MODULE environment var will only pass in exec_script, that's cause only stage-scripts, action.sh and uninstall scripts have this environment var

So, it cause customize.sh, and meta*.sh won't have this envionment var And module developers will see them can't use apd module config set command, because apd throw
`This command must be run in the context of a module or passed --internal <name>`

Taking the magic_mount_rs module as an example:
before:
```
APATCH='true'
```
after:
```
APATCH='true'
AP_MODULE='magic_mount_rs'
```