### PR TITLE
manager: fix TransactionTooLargeException crash on large module install logs

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/ExecuteAPMAction.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/ExecuteAPMAction.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -50,12 +51,17 @@ import java.util.Locale
 @Destination<RootGraph>
 fun ExecuteAPMActionScreen(navigator: DestinationsNavigator, moduleId: String) {
     var text by rememberSaveable { mutableStateOf("") }
-    var tempText: String
-    val logContent = rememberSaveable { StringBuilder() }
+    val logContent = remember { StringBuilder() }
     val snackBarHost = LocalSnackbarHost.current
     val scope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
     var actionResult: Boolean
+
+    fun appendLog(line: String) {
+        logContent.append(line).append("\n")
+        val newText = text + line + "\n"
+        text = if (newText.length > 100_000) newText.takeLast(100_000) else newText
+    }
 
     LaunchedEffect(Unit) {
         if (text.isNotEmpty()) {
@@ -65,16 +71,14 @@ fun ExecuteAPMActionScreen(navigator: DestinationsNavigator, moduleId: String) {
             runAPModuleAction(
                 moduleId,
                 onStdout = {
-                    tempText = "$it\n"
-                    if (tempText.startsWith("[H[J")) { // clear command
-                        text = tempText.substring(6)
+                    if (it.startsWith("\u001B[H\u001B[2J")) { // clear command
+                        text = it.substring(9)
                     } else {
-                        text += tempText
+                        appendLog(it)
                     }
-                    logContent.append(it).append("\n")
                 },
                 onStderr = {
-                    logContent.append(it).append("\n")
+                    appendLog(it)
                 }
             ).let {
                 actionResult = it

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Install.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Install.kt
@@ -76,10 +76,15 @@ enum class MODULE_TYPE {
 @Composable
 @Destination<RootGraph>
 fun InstallScreen(navigator: DestinationsNavigator, uri: Uri, type: MODULE_TYPE) {
-    var text by remember { mutableStateOf("") }
-    var tempText: String
+    var text by rememberSaveable { mutableStateOf("") }
     val logContent = remember { StringBuilder() }
     var showFloatAction by rememberSaveable { mutableStateOf(false) }
+
+    fun appendLog(line: String) {
+        logContent.append(line).append("\n")
+        val newText = text + line + "\n"
+        text = if (newText.length > 100_000) newText.takeLast(100_000) else newText
+    }
     val metaModuleAlertDialog = rememberCustomDialog { dismiss: () -> Unit ->
         val uriHandler = LocalUriHandler.current
         AlertDialog(
@@ -141,21 +146,17 @@ fun InstallScreen(navigator: DestinationsNavigator, uri: Uri, type: MODULE_TYPE)
                 }
 
             }, onStdout = {
-                tempText = "$it\n"
-                if (tempText.startsWith("[H[J")) { // clear command
-                    text = tempText.substring(6)
+                if (it.startsWith("[H[J")) { // clear command
+                    text = it.substring(5)
                 } else {
-                    text += tempText
+                    appendLog(it)
                 }
-                logContent.append(it).append("\n")
             }, onStderr = {
-                tempText = "$it\n"
-                if (tempText.startsWith("[H[J")) { // clear command
-                    text = tempText.substring(6)
+                if (it.startsWith("[H[J")) { // clear command
+                    text = it.substring(5)
                 } else {
-                    text += tempText
+                    appendLog(it)
                 }
-                logContent.append(it).append("\n")
             })
         }
     }


### PR DESCRIPTION
When installing modules that produce large log output (e.g. theme modules with thousands of icons), the install log text state grows unboundedly, causing TransactionTooLargeException when the Activity's saved state Bundle exceeds the Binder transaction limit (~1MB).

This was previously reported in #927 and fixed in cb684e6 by switching from rememberSaveable to remember, but that caused the log to reset on navigation (#1308).

Fix both issues by:
- Using rememberSaveable for text state (preserves log on navigation)
- Truncating text at runtime to 100K chars when it exceeds the limit
- Keeping full log in StringBuilder (remember) for saving to file
- Also fixing ExecuteAPMActionScreen which had the same issue

The 100K char limit (~100KB) is well below the Binder limit and still covers ~2000-3000 lines of install log output.

Closes: #927