### PR TITLE
manager: fix update dialog being re-opened on every recomposition

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Home.kt
@@ -736,16 +736,17 @@ fun UpdateCard() {
         val updateDialog = rememberConfirmDialog(onConfirm = { uriHandler.openUri(newVersionUrl) })
         WarningCard(
             message = stringResource(id = R.string.home_new_apatch_found).format(newVersionCode),
-            MaterialTheme.colorScheme.outlineVariant
-        ) {
-            if (changelog.isEmpty()) {
-                uriHandler.openUri(newVersionUrl)
-            } else {
-                updateDialog.showConfirm(
-                    title = title, content = changelog, markdown = true, confirm = updateText
-                )
+            color = MaterialTheme.colorScheme.outlineVariant,
+            onClick = {
+                if (changelog.isEmpty()) {
+                    uriHandler.openUri(newVersionUrl)
+                } else {
+                    updateDialog.showConfirm(
+                        title = title, content = changelog, markdown = true, confirm = updateText
+                    )
+                }
             }
-        }
+        )
     }
 }
 


### PR DESCRIPTION
The trailing lambda in UpdateCard bound to WarningCard's `icon` parameter instead of `onClick` since the component rewrite in 61e261d appended the icon slot after onClose. The click handler was therefore executed as a side effect during composition: every recomposition called showConfirm() and re-opened the changelog dialog, so canceling it only triggered another recomposition and the dialog could never stay closed.

Pass the handler explicitly as `onClick`.