### PR TITLE
apd: set target gid and support -g/-G options for su

### DIFF
--- a/apd/src/apd.rs
+++ b/apd/src/apd.rs
@@ -136,18 +136,21 @@ pub fn root_shell() -> Result<()> {
 
     // use current uid if no user specified, these has been done in kernel!
     let mut uid = unsafe { libc::getuid() };
-    let gid = unsafe { libc::getgid() };
+    let mut gid = unsafe { libc::getgid() };
     if free_idx < matches.free.len() {
         let name = &matches.free[free_idx];
-        uid = unsafe {
+        (uid, gid) = unsafe {
             #[cfg(target_arch = "aarch64")]
             let pw = libc::getpwnam(name.as_ptr()).as_ref();
             #[cfg(target_arch = "x86_64")]
             let pw = libc::getpwnam(name.as_ptr() as *const i8).as_ref();
 
             match pw {
-                Some(pw) => pw.pw_uid,
-                None => name.parse::<u32>().unwrap_or(0),
+                Some(pw) => (pw.pw_uid, pw.pw_gid),
+                None => {
+                    let uid = name.parse::<u32>().unwrap_or(0);
+                    (uid, uid)
+                }
             }
         }
     }

--- a/apd/src/apd.rs
+++ b/apd/src/apd.rs
@@ -5,7 +5,9 @@ use std::{env, ffi::CStr, path::PathBuf, process::Command};
 use anyhow::{Ok, Result};
 #[cfg(unix)]
 use getopts::Options;
-use rustix::thread::{Gid, Uid, set_thread_res_gid, set_thread_res_uid};
+use rustix::thread::{
+    Gid, Uid, set_thread_groups, set_thread_res_gid, set_thread_res_uid,
+};
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use crate::pty::prepare_pty;
@@ -14,15 +16,24 @@ use crate::{
     utils::{self, umask},
 };
 
-fn print_usage(opts: Options) {
+fn print_usage(opts: &Options) {
     let brief = "APatch\n\nUsage: <command> [options] [-] [user [argument...]]".to_string();
     print!("{}", opts.usage(&brief));
 }
 
-fn set_identity(uid: u32, gid: u32) {
+fn parse_gid(g: &str) -> Result<u32, std::num::ParseIntError> {
+    g.parse::<u32>()
+}
+
+fn set_identity(uid: u32, gid: u32, groups: &[u32]) {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     let gid = Gid::from_raw(gid);
     let uid = Uid::from_raw(uid);
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        let groups: Vec<Gid> = groups.iter().map(|&g| Gid::from_raw(g)).collect();
+        let _ = set_thread_groups(&groups);
+    }
     set_thread_res_gid(gid, gid, gid).ok();
     set_thread_res_uid(uid, uid, uid).ok();
 }
@@ -77,6 +88,13 @@ pub fn root_shell() -> Result<()> {
         "mount-master",
         "force run in the global mount namespace",
     );
+    opts.optopt("g", "group", "Specify the primary group", "GROUP");
+    opts.optmulti(
+        "G",
+        "supp-group",
+        "Specify a supplementary group. The first specified supplementary group is also used as a primary group if the option -g is not specified.",
+        "GROUP",
+    );
     opts.optflag("", "no-pty", "Do not allocate a new pseudo terminal.");
 
     // Replace -cn with -z, -mm with -M for supporting getopt_long
@@ -97,13 +115,13 @@ pub fn root_shell() -> Result<()> {
         Result::Ok(m) => m,
         Err(f) => {
             println!("{f}");
-            print_usage(opts);
+            print_usage(&opts);
             std::process::exit(-1);
         }
     };
 
     if matches.opt_present("h") {
-        print_usage(opts);
+        print_usage(&opts);
         return Ok(());
     }
 
@@ -121,6 +139,19 @@ pub fn root_shell() -> Result<()> {
     let mut is_login = matches.opt_present("l");
     let preserve_env = matches.opt_present("p");
     let mount_master = matches.opt_present("M");
+
+    // -g overrides the primary group, -G appends supplementary groups
+    let groups = matches
+        .opt_strs("G")
+        .into_iter()
+        .map(|g| {
+            parse_gid(&g).unwrap_or_else(|_| {
+                println!("Invalid GID: {g}");
+                print_usage(&opts);
+                std::process::exit(-1);
+            })
+        })
+        .collect::<Vec<u32>>();
 
     // we've made sure that -c is the last option and it already contains the whole command, no need to construct it again
     let args = matches
@@ -153,6 +184,18 @@ pub fn root_shell() -> Result<()> {
                 }
             }
         }
+    }
+
+    if let Some(g) = matches.opt_str("g").map(|g| {
+        parse_gid(&g).unwrap_or_else(|_| {
+            println!("Invalid GID: {g}");
+            print_usage(&opts);
+            std::process::exit(-1);
+        })
+    }) {
+        gid = g;
+    } else if !groups.is_empty() {
+        gid = groups[0];
     }
 
     // https://github.com/topjohnwu/Magisk/blob/master/native/src/core/su/su_daemon.cpp#L408
@@ -211,7 +254,7 @@ pub fn root_shell() -> Result<()> {
                 let _ = utils::switch_mnt_ns(1);
             }
 
-            set_identity(uid, gid);
+            set_identity(uid, gid, &groups);
 
             Result::Ok(())
         })


### PR DESCRIPTION
## Summary

1. **Set the gid of the target user in root shell**
   - The primary group is now taken from the passwd entry when a user
     is specified
   - Falls back to the Android convention of `gid == uid` for numeric
     users
   - Previously the caller's gid (usually root's) was kept, giving
     unintended group access

2. **Support `-g`/`-G` options**
   - `-g, --group GROUP`: override the primary group
   - `-G, --supp-group GROUP`: append supplementary groups (repeatable)
   - Without `-g`, the first `-G` doubles as the primary group
   - The target never inherits the daemon's supplementary groups

## Relation to issues

- **Partially addresses #1473**: `su shell` now yields
  `uid=2000 gid=2000` instead of `gid=0(root)`. The target user's
  supplementary groups are not auto-injected: that would mean
  hardcoding Android-specific group lists (adbd's shell groups are a
  daemon-specific fixed set, not a general su behavior). Instead,
  callers can specify supplementary groups explicitly with `-G`. The
  SELinux context (`u:r:shell:s0`) is also unchanged.
- **Partially implements #1529**: `-g`/`-G` done. `-Z/--context` is
  not implemented yet: setting a custom SELinux context requires
  kernel-side support.

## Behavior

```console
$ su shell -c 'id -u; id -g'
2000
2000
$ su -G 3003 -G 2000 -c 'id -G'
3003 2000
$ su -g 2000 -G 3003 -c 'id -G'
2000 3003
$ su -g root -c id
Invalid GID: root
```

- Invalid GIDs fail closed: print error + usage, exit 255
- `set_thread_groups` runs before `setresgid`/`setresuid` (required,
  since `setuid` drops `CAP_SETGID`)

## Testing

Verified on device with an equivalence-class test (21 cases):
user parsing, `-g` (valid/zero/group-name/negative/out-of-range), `-G`
(single/multiple/priority/invalid), and combinations — all passing.

Partially addresses #1473
Partially implements #1529

## References
- https://github.com/tiann/KernelSU/blob/main/userspace/ksud/src/su.rs
- https://github.com/topjohnwu/Magisk/blob/master/native/src/core/su/su.cpp
- https://android.googlesource.com/platform/system/core/+/bcd37e67dbf1e420c41b7cbaa22142c14ec5d8fc/adb/daemon/main.cpp