### PR TITLE
fix(kpm): hide the enable toggle on plain-Loaded modules

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/KPModuleViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/KPModuleViewModel.kt
@@ -81,7 +81,10 @@ class KPModuleViewModel : ViewModel() {
                         safeKpmModuleId(kernelName),
                         lines.firstOrNull { it.startsWith("load_source=") }?.removePrefix("load_source=") ?: ""
                     )
-                    result[info.moduleId] = info.copy(installed = info.loadSource == "file")
+                    // Only KPMs with a persistent file in KPMS_DIR are "installed";
+                    // a plain Load (load-source "file") has no disable marker to
+                    // control, so it must not show the toggle.
+                    result[info.moduleId] = info.copy(installed = false)
                 }
                 val dirs = rootShellForResult("find ${APApplication.KPMS_DIR} -mindepth 1 -maxdepth 1 -type d -print").out
                 dirs.map { it.trim().substringAfterLast('/') }.filter(String::isNotBlank).forEach { id ->


### PR DESCRIPTION
## Problem

`installed = (loadSource == "file")` marks modules loaded via **Load** as installed even though they have no file in `KPMS_DIR`. As a result:

- The enable/disable Switch shows up on Load-loaded modules
- But the toggle does nothing: there is no disable marker to control (the module has no persistent file and disappears after reboot anyway)

## Fix

`installed` is now only true for modules found in `KPMS_DIR` (actually installed, reboot-persistent). Kernel-list entries start with `installed=false`, and the `KPMS_DIR` scan overrides them via the same `safeKpmModuleId` key, so Install-ed modules keep their working toggle.

## Behavior after fix

| Module source | Toggle |
|---|---|
| Load (temporary) | hidden (no disable marker exists) |
| Install (KPMS_DIR) | shown, works (disable marker is real) |
| Embedded | not shown (frozen into boot image)