### PR TITLE
fix: keep KPM install and unload state consistent

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/KPM.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/KPM.kt
@@ -81,6 +81,8 @@ import com.topjohnwu.superuser.nio.ExtendedFile
 import com.topjohnwu.superuser.nio.FileSystemManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import me.bmax.apatch.APApplication
 import me.bmax.apatch.Natives
@@ -107,6 +109,11 @@ import java.io.StringReader
 import org.ini4j.Ini
 
 private const val TAG = "KernelPatchModule"
+private val kpmInstallMutex = Mutex()
+private data class UninstallResult(
+    val unloaded: Boolean,
+    val removed: Boolean,
+)
 private lateinit var targetKPMToControl: KPModel.KPMInfo
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -204,10 +211,9 @@ fun KPModuleScreen(navigator: DestinationsNavigator) {
                 if (it.resultCode != RESULT_OK) return@rememberLauncherForActivityResult
                 val uri = it.data?.data ?: return@rememberLauncherForActivityResult
                 scope.launch {
-                    val rc = installKpm(uri)
+                    val rc = kpmInstallMutex.withLock { installKpm(uri) }
                     Toast.makeText(context, if (rc == 0) installSuccessToastText else "$failToastText: $rc", Toast.LENGTH_SHORT).show()
                     viewModel.markNeedRefresh()
-                    viewModel.fetchModuleList()
                 }
             }
 
@@ -487,17 +493,22 @@ private fun KPModuleList(
             return
         }
 
-        val success = loadingDialog.withLoading {
+        val result = loadingDialog.withLoading {
             withContext(Dispatchers.IO) {
                 val unloaded = module.loadSource.isBlank() || Natives.unloadKernelPatchModule(module.name) == 0L
-                if (module.installed && module.loadSource != "embedded") {
+                val removed = if (module.installed && module.loadSource != "embedded") {
                     val id = safeKpmModuleId(module.moduleId.ifBlank { module.name })
-                    rootShellForResult("rm -rf '${APApplication.KPMS_DIR}$id'").isSuccess && (unloaded || module.disabled)
-                } else unloaded
+                    val dir = "${APApplication.KPMS_DIR}$id"
+                    rootShellForResult("rm -rf '$dir' && test ! -e '$dir'").isSuccess
+                } else true
+                UninstallResult(unloaded, removed)
             }
         }
 
-        if (success) {
+        // Refresh even when the live kernel instance could not be unloaded:
+        // the persistent file may still have been removed and must not remain
+        // represented as installed in the UI.
+        if (result.removed) {
             viewModel.fetchModuleList()
         }
     }

--- a/app/src/main/java/me/bmax/apatch/ui/viewmodel/KPModuleViewModel.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/viewmodel/KPModuleViewModel.kt
@@ -91,8 +91,15 @@ class KPModuleViewModel : ViewModel() {
             val start = SystemClock.elapsedRealtime()
             runCatching {
                 val result = linkedMapOf<String, KPModel.KPMInfo>()
-                var names = Natives.kernelPatchModuleList()
-                if (Natives.kernelPatchModuleNum() <= 0) names = ""
+                val names = if (Natives.kernelPatchModuleNum() > 0) {
+                    Natives.kernelPatchModuleList()
+                } else {
+                    ""
+                }
+                val loadedIds = names.split('\n')
+                    .map(String::trim)
+                    .filter(String::isNotBlank)
+                    .toSet()
                 names.split('\n').filter(String::isNotBlank).forEach { kernelName ->
                     val lines = Natives.kernelPatchModuleInfo(kernelName).split('\n')
                     val info = KPModel.KPMInfo(
@@ -121,7 +128,11 @@ class KPModuleViewModel : ViewModel() {
                     val key = safeKpmModuleId(id)
                     val old = result[key]
                     // Refresh the same live metadata exposed by `truncate su module info <name>`.
-                    val live = parseKernelKpmInfo(Natives.kernelPatchModuleInfo(id), id)
+                    val live = if (id in loadedIds) {
+                        parseKernelKpmInfo(Natives.kernelPatchModuleInfo(id), id)
+                    } else {
+                        null
+                    }
                     val current = live ?: old
                     val disabled = rootShellForResult("[ -e '${APApplication.KPMS_DIR}$id/disable' ]").isSuccess
                     result[key] = current?.copy(


### PR DESCRIPTION
## Summary

In the KPM management flow, uninstall state was inconsistent: installing a module then immediately unloading it left the UI in a stale state, and the persistent file under `/data/adb/ap/kpm/<id>/` could remain after the module appeared removed.

This change decouples the install/unload decisions so the UI reflects what actually happened on disk and in the kernel.

## Changes

### `KPModuleViewModel.kt`
- Only call `Natives.kernelPatchModuleList()` when the kernel actually reports a nonzero module count.
- Skip `Natives.kernelPatchModuleInfo(id)` for modules that are not in the loaded kernel list; freshly installed (not yet rebooted) modules no longer trigger a live kernel lookup.

### `KPM.kt`
- After an **install**, only mark the list for refresh on next entry / manual refresh (module takes effect after reboot). Do not immediately re-query the kernel for a module that is not loaded yet.
- Serialize installs with a mutex so rapid taps cannot delete each other's shared temporary staging directory.
- On **uninstall**, decouple live kernel unload from persistent file removal:
  - Try unloading the running instance.
  - Independently remove and verify the persistence directory (`rm -rf ... && test ! -e ...`).
  - Refresh the list whenever the persistent file was actually removed, even if the live kernel unload returned nonzero.

## Why

KPM installed via the "Install" action is only loaded by the boot-time loader after reboot. Re-querying the kernel for it immediately after install (and the combined uninstall condition) made the UI show the module as present/removed incorrectly, and could leave a stale `/data/adb/ap/kpm/<id>/<id>.kpm` entry after uninstall.
